### PR TITLE
Fix crash on exception from malformed messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ fixed location, while still reading SMS on a separate "Mirror" device. The Mirro
 privacy-focused eSIM or Wi‑Fi for internet access, reducing the risk of location tracking tied to your
 phone number on the device you carry.
 
+This application does **not** mitigate the inherent security flaws in the SMS protocol. SMS messages 
+are still delivered to the Host device connected to the phone network. The app’s purpose is to allow 
+you to receive and read SMS messages on a separate Mirror device, while keeping the connected Host 
+device in a fixed location.
+
 ## How it works
 
 - Encrypted forwarding: Incoming SMS messages on the Host are serialized and AES-encrypted, then sent to a ntfy
@@ -50,7 +55,6 @@ for mirroring, as all network traffic is handled by the ntfy app.
 
 ## Security Notes
 
-- Messages are encrypted with AES before being sent via ntfy.
 - The encryption key is generated and stored locally on each device. **If lost, messages cannot be decrypted.**
 - The ntfy server handles transport but does not decrypt messages. For maximum privacy, consider [self-hosting ntfy](https://docs.ntfy.sh/install/).
 

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -200,6 +200,7 @@
     <ID>TooGenericExceptionCaught:MessagingUtils.kt$MessagingUtils$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MmsReceiver.kt$MmsReceiver$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NewConversationActivity.kt$NewConversationActivity$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:NtfySmsReceiverService.kt$NtfySmsReceiverService.&lt;no name provided&gt;$e: Exception</ID>
     <ID>TooGenericExceptionCaught:RecycleBinConversationsActivity.kt$RecycleBinConversationsActivity$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ScheduledMessageReceiver.kt$ScheduledMessageReceiver$e: Error</ID>
     <ID>TooGenericExceptionCaught:ScheduledMessageReceiver.kt$ScheduledMessageReceiver$e: Exception</ID>

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/NtfySmsReceiverService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/NtfySmsReceiverService.kt
@@ -29,6 +29,8 @@ import org.fossify.messages.R
 import org.fossify.messages.activities.MainActivity
 import org.fossify.messages.extensions.getThreadId
 import org.fossify.messages.receivers.SmsReceiver
+import javax.crypto.BadPaddingException
+import javax.crypto.IllegalBlockSizeException
 import javax.crypto.spec.SecretKeySpec
 
 
@@ -59,9 +61,18 @@ class NtfySmsReceiverService : Service() {
                 decryptedMessage = CryptoHelper.decrypt(encryptedMessage, key)
             }
             catch (e: Exception) {
-                context.showErrorToast(e)
-                return
+                when (e) {
+                    is IndexOutOfBoundsException,
+                    is IllegalArgumentException,
+                    is IllegalBlockSizeException,
+                    is BadPaddingException -> {
+                        context.showErrorToast(e)
+                        return
+                    }
+                    else -> throw e
+                }
             }
+
 
             val dto = EventDto.Companion.Serializer.decodeFromString<EventDto>(decryptedMessage)
             if (dto !is EventDto.SmsReceive) return

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/NtfySmsReceiverService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/NtfySmsReceiverService.kt
@@ -58,8 +58,9 @@ class NtfySmsReceiverService : Service() {
             try {
                 decryptedMessage = CryptoHelper.decrypt(encryptedMessage, key)
             }
-            catch (e: IllegalArgumentException) {
+            catch (e: Exception) {
                 context.showErrorToast(e)
+                return
             }
 
             val dto = EventDto.Companion.Serializer.decodeFromString<EventDto>(decryptedMessage)


### PR DESCRIPTION
 - Missing return statement
 - Other exceptions possible besides that handles in original catch
 -  Add note in readme about security flaws in SMS