### PR TITLE
Add SMS send request from a Mirror to a SMS Host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ While the Messages Mirror app provides core functionality for SMS mirroring, som
 | Direct Reply (`DirectReplyReceiver`)                | Not implemented | Inline reply handling is not mirrored.        |
 | Mark as Read (`MarkAsReadReceiver`)                 | Not implemented | Read status updates are not mirrored.         |
 
-### Sending SMS Messages
-
-Currently, **sending SMS messages is performed directly from the Mirror device**. This means that while incoming messages are mirrored from the Host device, outgoing messages are sent by the Mirror device itself. Effectively meaning that sending SMS messages if not supported if the mirror device does not contain a SIM card. Future updates may introduce options to route outgoing messages through the Host device for full mirroring functionality.
-
 ## Troubleshooting
 
 - **Messages not appearing?**  

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -148,7 +148,7 @@
     <ID>NestedBlockDepth:Context.kt$fun Context.getThreadParticipants( threadId: Long, contactsMap: HashMap&lt;Int, SimpleContact&gt;?, ): ArrayList&lt;SimpleContact&gt;</ID>
     <ID>NestedBlockDepth:MessagesImporter.kt$MessagesImporter$private fun InputStream.importXml()</ID>
     <ID>NestedBlockDepth:MessagesWriter.kt$MessagesWriter$@SuppressLint("NewApi") private fun writeMmsPart(mmsPart: MmsPart, messageId: Long)</ID>
-    <ID>NestedBlockDepth:Messaging.kt$fun Context.sendMessageCompat( text: String, addresses: List&lt;String&gt;, subId: Int?, attachments: List&lt;Attachment&gt;, messageId: Long? = null )</ID>
+    <ID>NestedBlockDepth:Messaging.kt$fun Context.sendMessageOnDeviceCompat( text: String, addresses: List&lt;String&gt;, subId: Int?, attachments: List&lt;Attachment&gt;, messageId: Long? = null )</ID>
     <ID>NestedBlockDepth:MessagingUtils.kt$MessagingUtils$@Deprecated("TODO: Move/rewrite MMS code into the app.") fun sendMmsMessage( text: String, addresses: List&lt;String&gt;, attachment: Attachment?, settings: Settings, messageId: Long? = null )</ID>
     <ID>NestedBlockDepth:MessagingUtils.kt$MessagingUtils$fun updateSmsMessageSendingStatus(messageUri: Uri?, type: Int)</ID>
     <ID>NestedBlockDepth:SmsStatusDeliveredReceiver.kt$SmsStatusDeliveredReceiver$override fun updateAndroidDatabase(context: Context, intent: Intent, receiverResultCode: Int)</ID>
@@ -200,7 +200,7 @@
     <ID>TooGenericExceptionCaught:MessagingUtils.kt$MessagingUtils$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MmsReceiver.kt$MmsReceiver$e: Exception</ID>
     <ID>TooGenericExceptionCaught:NewConversationActivity.kt$NewConversationActivity$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:NtfySmsReceiverService.kt$NtfySmsReceiverService.&lt;no name provided&gt;$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:EventConsumerService.kt$EventConsumerService.&lt;no name provided&gt;$e: Exception</ID>
     <ID>TooGenericExceptionCaught:RecycleBinConversationsActivity.kt$RecycleBinConversationsActivity$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ScheduledMessageReceiver.kt$ScheduledMessageReceiver$e: Error</ID>
     <ID>TooGenericExceptionCaught:ScheduledMessageReceiver.kt$ScheduledMessageReceiver$e: Exception</ID>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -193,7 +193,7 @@
 
         <!-- org.cpardi.messagemirror  -->
         <service
-            android:name="org.cpardi.messagemirror.services.NtfySmsReceiverService"
+            android:name="org.cpardi.messagemirror.services.EventConsumerService"
             android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
@@ -201,7 +201,7 @@
         </service>
 
         <receiver
-            android:name="org.cpardi.messagemirror.services.NtfySmsReceiverService$BootStartReceiver"
+            android:name="org.cpardi.messagemirror.services.EventConsumerService$BootStartReceiver"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
@@ -211,7 +211,7 @@
         </receiver>
 
         <receiver
-            android:name="org.cpardi.messagemirror.services.NtfySmsReceiverService$AutoRestartReceiver"
+            android:name="org.cpardi.messagemirror.services.EventConsumerService$AutoRestartReceiver"
             android:enabled="true"
             android:exported="false"/>
 

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
@@ -1,0 +1,33 @@
+package org.cpardi.messagemirror.extensions
+
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.util.Base64
+import org.cpardi.messagemirror.helpers.CryptoHelper
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver.Companion.NTFY_MESSAGE
+import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver.Companion.NTFY_PACKAGE
+import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver.Companion.NTFY_SEND_MESSAGE_ACTION
+import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver.Companion.NTFY_TOPIC
+import org.cpardi.messagemirror.views.MirrorSettingsView
+import org.fossify.commons.helpers.ensureBackgroundThread
+import javax.crypto.spec.SecretKeySpec
+
+fun Context.broadcastEvent(prefs: SharedPreferences, dto: EventDto) {
+    val topic = prefs.getString(MirrorSettingsView.Companion.TOPIC_NAME, "")
+    val keyBase64 = prefs.getString(MirrorSettingsView.ENCRYPTION_KEY_NAME, null)
+    val keyBytes = Base64.decode(keyBase64, Base64.NO_WRAP)
+    val key = SecretKeySpec(keyBytes, CryptoHelper.ALGORITHM)
+
+    ensureBackgroundThread {
+        val message = EventDto.Serializer.encodeToString(dto)
+        val encryptedMessage = CryptoHelper.encrypt(message, key)
+
+        val ntfyIntent = Intent(NTFY_SEND_MESSAGE_ACTION)
+        ntfyIntent.setPackage(NTFY_PACKAGE)
+        ntfyIntent.putExtra(NTFY_TOPIC, topic)
+        ntfyIntent.putExtra(NTFY_MESSAGE, encryptedMessage)
+        this.sendBroadcast(ntfyIntent)
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/Constants.kt
@@ -1,3 +1,7 @@
 package org.cpardi.messagemirror.helpers
 
-const val SETTINGS_NAME = "org.cpardi.messagemirror"
+object Constants {
+    const val SETTINGS_NAME = "org.cpardi.messagemirror"
+    const val MODE_NAME = "mode"
+    const val DEVICE_ID_NAME = "device_id"
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsReceiveHandler.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsReceiveHandler.kt
@@ -1,0 +1,63 @@
+package org.cpardi.messagemirror.helpers
+
+import android.content.Context
+import android.provider.Telephony
+import org.cpardi.messagemirror.models.EventDto
+import org.fossify.commons.extensions.baseConfig
+import org.fossify.commons.extensions.getMyContactsCursor
+import org.fossify.commons.helpers.SimpleContactsHelper
+import org.fossify.commons.helpers.ensureBackgroundThread
+import org.fossify.messages.extensions.getThreadId
+import org.fossify.messages.receivers.SmsReceiver
+
+class SmsReceiveHandler(val deviceID: String) {
+    fun handle(subscriptionId: Int, context: Context, dto: EventDto.SmsReceive) {
+        if (deviceID == dto.metadata.senderID)
+            return
+
+        val address = dto.address
+        val body = dto.body
+        val subject = dto.subject
+        val date = System.currentTimeMillis()
+        val threadId = context.getThreadId(address)
+        val status = Telephony.Sms.STATUS_NONE
+        val type = Telephony.Sms.MESSAGE_TYPE_INBOX
+        val read = 0
+
+        val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
+        ensureBackgroundThread {
+            if (context.baseConfig.blockUnknownNumbers) {
+                val simpleContactsHelper = SimpleContactsHelper(context)
+                simpleContactsHelper.exists(address, privateCursor) { exists ->
+                    if (exists) {
+                        SmsReceiver.Companion.handleMessage(
+                            context,
+                            address,
+                            subject,
+                            body,
+                            date,
+                            read,
+                            threadId,
+                            type,
+                            subscriptionId,
+                            status
+                        )
+                    }
+                }
+            } else {
+                SmsReceiver.Companion.handleMessage(
+                    context,
+                    address,
+                    subject,
+                    body,
+                    date,
+                    read,
+                    threadId,
+                    type,
+                    subscriptionId,
+                    status
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsSendHandler.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsSendHandler.kt
@@ -1,0 +1,29 @@
+package org.cpardi.messagemirror.helpers
+
+import android.content.Context
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.fromDto
+import org.fossify.commons.helpers.ensureBackgroundThread
+import org.fossify.messages.helpers.refreshConversations
+import org.fossify.messages.helpers.refreshMessages
+import org.fossify.messages.messaging.sendMessageOnDeviceCompat
+
+class SmsSendHandler(val deviceID: String) {
+    fun handle(context: Context, dto: EventDto.SmsSend) {
+        if (deviceID == dto.metadata.senderID)
+            return
+
+        ensureBackgroundThread {
+            context.sendMessageOnDeviceCompat(
+                dto.text,
+                dto.addresses,
+                dto.subId,
+                dto.attachments.map { attachmentDto -> attachmentDto.fromDto() },
+                dto.messageId
+            )
+
+            refreshMessages()
+            refreshConversations()
+        }
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/AttachmentDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/AttachmentDto.kt
@@ -1,0 +1,39 @@
+package org.cpardi.messagemirror.models
+
+import kotlinx.serialization.Serializable
+import org.fossify.messages.models.Attachment
+
+@Serializable
+data class AttachmentDto(
+    val id: Long?,
+    val messageId: Long,
+    val uriString: String,
+    val mimetype: String,
+    val width: Int,
+    val height: Int,
+    val filename: String
+)
+
+fun AttachmentDto.fromDto(): Attachment {
+    return Attachment(
+        this.id,
+        this.messageId,
+        this.uriString,
+        this.mimetype,
+        this.width,
+        this.height,
+        this.filename
+    )
+}
+
+fun Attachment.toDto(): AttachmentDto {
+    return AttachmentDto(
+        this.id,
+        this.messageId,
+        this.uriString,
+        this.mimetype,
+        this.width,
+        this.height,
+        this.filename
+    )
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/DeviceMode.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/DeviceMode.kt
@@ -1,0 +1,16 @@
+package org.cpardi.messagemirror.models
+
+enum class DeviceMode(val value: Int) {
+    SmsHost(1),
+    Mirror(2);
+
+    fun description(): String = when (this) {
+        SmsHost -> "SMS Host"
+        Mirror -> "Mirror"
+    }
+
+    companion object {
+        fun fromInt(value: Int): DeviceMode = entries.find { it.value == value }
+            ?: throw IllegalArgumentException("Invalid Mode value: $value")
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
@@ -11,11 +11,11 @@ import kotlinx.serialization.modules.subclass
 sealed class EventDto {
     /** Represents when an SMS message is received by the SMS host */
     @Serializable
-    data class SmsReceive(val address: String, val subject: String, val status: Int, val body: String, val date: Long) : EventDto()
+    data class SmsReceive(val metadata: EventMetadataDto, val address: String, val subject: String, val status: Int, val body: String, val date: Long) : EventDto()
 
-    /** Represents when an SMS message is send by a Mirror */
+    /** Represents when an SMS message is sent by a Mirror */
     @Serializable
-    data class SmsSend(val addresses: List<String>, val subject: String, val status: Int, val body: String, val date: Long) : EventDto()
+    data class SmsSend(val metadata: EventMetadataDto, val text: String, val addresses: List<String>, val subId: Int?, val attachments: List<AttachmentDto>, val messageId: Long?) : EventDto()
 
     companion object {
         /** Enables polymorphic serialisation for this class */

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
@@ -11,11 +11,25 @@ import kotlinx.serialization.modules.subclass
 sealed class EventDto {
     /** Represents when an SMS message is received by the SMS host */
     @Serializable
-    data class SmsReceive(val metadata: EventMetadataDto, val address: String, val subject: String, val status: Int, val body: String, val date: Long) : EventDto()
+    data class SmsReceive(
+        val metadata: EventMetadataDto,
+        val address: String,
+        val subject: String,
+        val status: Int,
+        val body: String,
+        val date: Long
+    ) : EventDto()
 
     /** Represents when an SMS message is sent by a Mirror */
     @Serializable
-    data class SmsSend(val metadata: EventMetadataDto, val text: String, val addresses: List<String>, val subId: Int?, val attachments: List<AttachmentDto>, val messageId: Long?) : EventDto()
+    data class SmsSend(
+        val metadata: EventMetadataDto,
+        val text: String,
+        val addresses: List<String>,
+        val subId: Int?,
+        val attachments: List<AttachmentDto>,
+        val messageId: Long?
+    ) : EventDto()
 
     companion object {
         /** Enables polymorphic serialisation for this class */

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/EventMetadataDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/EventMetadataDto.kt
@@ -1,0 +1,6 @@
+package org.cpardi.messagemirror.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EventMetadataDto(val senderID: String)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/MessageAttachmentDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/MessageAttachmentDto.kt
@@ -1,0 +1,10 @@
+package org.cpardi.messagemirror.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MessageAttachmentDto(
+    val id: Long,
+    val text: String,
+    val attachments: ArrayList<AttachmentDto>
+)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
@@ -4,14 +4,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.provider.Telephony
-import android.util.Base64
-import org.cpardi.messagemirror.helpers.CryptoHelper
-import org.cpardi.messagemirror.helpers.SETTINGS_NAME
+import org.cpardi.messagemirror.extensions.broadcastEvent
+import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.EventMetadataDto
 import org.cpardi.messagemirror.views.MirrorSettingsView
 import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.messages.receivers.SmsReceiver
-import javax.crypto.spec.SecretKeySpec
 
 class ForwardingSmsReceiver(private val wrappedReceiver: SmsReceiver = SmsReceiver()) :
     BroadcastReceiver() {
@@ -27,13 +26,10 @@ class ForwardingSmsReceiver(private val wrappedReceiver: SmsReceiver = SmsReceiv
         if (intent.action != SMS_DELIVER_ACTION) return
 
         wrappedReceiver.onReceive(context, intent)
+        val prefs = context.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE)
+        val isEnabled = prefs.getBoolean(MirrorSettingsView.ENABLE_NAME, false)
 
-        val prefs = context.getSharedPreferences(SETTINGS_NAME, Context.MODE_PRIVATE)
-         val isEnabled = prefs.getBoolean(MirrorSettingsView.ENABLE_NAME, false)
-        val mode = MirrorSettingsView.DeviceMode.fromInt(prefs.getInt(MirrorSettingsView.MODE_NAME, MirrorSettingsView.DeviceMode.SmsHost.value))
-        val topic = prefs.getString(MirrorSettingsView.TOPIC_NAME, "")
-
-        if (!isEnabled || mode != MirrorSettingsView.DeviceMode.SmsHost) return
+        if (!isEnabled) return
 
         val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
         var address = ""
@@ -51,20 +47,10 @@ class ForwardingSmsReceiver(private val wrappedReceiver: SmsReceiver = SmsReceiv
                 date = System.currentTimeMillis()
             }
 
-            val dto: EventDto = EventDto.SmsReceive(address, subject, status, body, date)
-            val message = EventDto.Serializer.encodeToString(dto)
-
-            val keyBase64 = prefs.getString(MirrorSettingsView.ENCRYPTION_KEY_NAME, null)
-            val keyBytes = Base64.decode(keyBase64, Base64.NO_WRAP)
-            val key = SecretKeySpec(keyBytes, CryptoHelper.ALGORITHM)
-
-            val encryptedMessage = CryptoHelper.encrypt(message, key)
-
-            val ntfyIntent = Intent(NTFY_SEND_MESSAGE_ACTION)
-            ntfyIntent.setPackage(NTFY_PACKAGE)
-            ntfyIntent.putExtra(NTFY_TOPIC, topic)
-            ntfyIntent.putExtra(NTFY_MESSAGE, encryptedMessage)
-            context.sendBroadcast(ntfyIntent)
+            val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() } ?: throw IllegalStateException("Device ID is null or empty")
+            val metadata = EventMetadataDto(deviceID)
+            val dto: EventDto = EventDto.SmsReceive(metadata, address, subject, status, body, date)
+            context.broadcastEvent(prefs, dto)
         }
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
@@ -47,7 +47,8 @@ class ForwardingSmsReceiver(private val wrappedReceiver: SmsReceiver = SmsReceiv
                 date = System.currentTimeMillis()
             }
 
-            val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() } ?: throw IllegalStateException("Device ID is null or empty")
+            val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() }
+                ?: error("Device ID is null or empty")
             val metadata = EventMetadataDto(deviceID)
             val dto: EventDto = EventDto.SmsReceive(metadata, address, subject, status, body, date)
             context.broadcastEvent(prefs, dto)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
@@ -11,31 +11,25 @@ import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
-import android.provider.Telephony
 import android.util.Base64
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import org.cpardi.messagemirror.helpers.CryptoHelper
-import org.cpardi.messagemirror.helpers.SETTINGS_NAME
+import org.cpardi.messagemirror.helpers.Constants
+import org.cpardi.messagemirror.helpers.SmsReceiveHandler
+import org.cpardi.messagemirror.helpers.SmsSendHandler
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver
 import org.cpardi.messagemirror.views.MirrorSettingsView
-import org.fossify.commons.extensions.baseConfig
-import org.fossify.commons.extensions.getMyContactsCursor
 import org.fossify.commons.extensions.showErrorToast
-import org.fossify.commons.helpers.SimpleContactsHelper
-import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.messages.R
 import org.fossify.messages.activities.MainActivity
-import org.fossify.messages.extensions.getThreadId
-import org.fossify.messages.receivers.SmsReceiver
 import javax.crypto.BadPaddingException
 import javax.crypto.IllegalBlockSizeException
 import javax.crypto.spec.SecretKeySpec
 
-
-class NtfySmsReceiverService : Service() {
+class EventConsumerService : Service() {
 
     companion object {
         const val NTFY_RECEIVE_MESSAGE_ACTION = "io.heckel.ntfy.MESSAGE_RECEIVED"
@@ -53,15 +47,16 @@ class NtfySmsReceiverService : Service() {
         }
     }
 
-    private val messageReceiver = object : BroadcastReceiver() {
+    private val eventReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-            val prefs = context.getSharedPreferences(SETTINGS_NAME, MODE_PRIVATE)
+            val prefs = context.getSharedPreferences(Constants.SETTINGS_NAME, MODE_PRIVATE)
             val isEnabled = prefs.getBoolean(MirrorSettingsView.Companion.ENABLE_NAME, false)
-            val mode = MirrorSettingsView.DeviceMode.fromInt(prefs.getInt(MirrorSettingsView.Companion.MODE_NAME, MirrorSettingsView.DeviceMode.SmsHost.value))
             val subscribedTopic = prefs.getString(MirrorSettingsView.Companion.TOPIC_NAME, "")
+            val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() }
+                ?: throw IllegalStateException("Device ID is null or empty")
             val topic = intent.getStringExtra(ForwardingSmsReceiver.Companion.NTFY_TOPIC)
 
-            if (!isEnabled || mode != MirrorSettingsView.DeviceMode.Mirror || topic != subscribedTopic)
+            if (!isEnabled || topic != subscribedTopic)
                 return
 
             val keyBase64 = prefs.getString(MirrorSettingsView.Companion.ENCRYPTION_KEY_NAME, null)
@@ -72,8 +67,7 @@ class NtfySmsReceiverService : Service() {
             var decryptedMessage = ""
             try {
                 decryptedMessage = CryptoHelper.decrypt(encryptedMessage, key)
-            }
-            catch (e: Exception) {
+            } catch (e: Exception) {
                 when (e) {
                     is IndexOutOfBoundsException,
                     is IllegalArgumentException,
@@ -82,58 +76,17 @@ class NtfySmsReceiverService : Service() {
                         context.showErrorToast(e)
                         return
                     }
+
                     else -> throw e
                 }
             }
 
-
-            val dto = EventDto.Companion.Serializer.decodeFromString<EventDto>(decryptedMessage)
-            if (dto !is EventDto.SmsReceive) return
-
-            val address = dto.address
-            val body = dto.body
-            val subject = dto.subject
-            val date = System.currentTimeMillis()
-            val threadId = context.getThreadId(address)
-            val status = Telephony.Sms.STATUS_NONE
-            val type = Telephony.Sms.MESSAGE_TYPE_INBOX
-            val read = 0
             val subscriptionId = intent.getIntExtra("subscription", -1)
-
-            val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
-            ensureBackgroundThread {
-                if (context.baseConfig.blockUnknownNumbers) {
-                    val simpleContactsHelper = SimpleContactsHelper(context)
-                    simpleContactsHelper.exists(address, privateCursor) { exists ->
-                        if (exists) {
-                            SmsReceiver.Companion.handleMessage(
-                                context,
-                                address,
-                                subject,
-                                body,
-                                date,
-                                read,
-                                threadId,
-                                type,
-                                subscriptionId,
-                                status
-                            )
-                        }
-                    }
-                } else {
-                    SmsReceiver.Companion.handleMessage(
-                        context,
-                        address,
-                        subject,
-                        body,
-                        date,
-                        read,
-                        threadId,
-                        type,
-                        subscriptionId,
-                        status
-                    )
-                }
+            val dto = EventDto.Companion.Serializer.decodeFromString<EventDto>(decryptedMessage)
+            when (dto) {
+                is EventDto.SmsReceive -> SmsReceiveHandler(deviceID).handle(subscriptionId, context, dto)
+                is EventDto.SmsSend -> SmsSendHandler(deviceID).handle(context, dto)
+                else -> return
             }
         }
     }
@@ -141,7 +94,7 @@ class NtfySmsReceiverService : Service() {
     override fun onCreate() {
         super.onCreate()
         val filter = IntentFilter(NTFY_RECEIVE_MESSAGE_ACTION)
-        ContextCompat.registerReceiver(this, messageReceiver, filter, ContextCompat.RECEIVER_EXPORTED)
+        ContextCompat.registerReceiver(this, eventReceiver, filter, ContextCompat.RECEIVER_EXPORTED)
 
         val channelId = "messagesMirror-subscriber"
         val notificationGroupId = "org.cpardi.messagemirror.NOTIFICATION_GROUP"
@@ -159,8 +112,8 @@ class NtfySmsReceiverService : Service() {
             .build()
 
 
-        val channelName = "MessageMirrorChannel"
-        val channel = NotificationChannel(channelId,  channelName, NotificationManager.IMPORTANCE_LOW).let {
+        val channelName = "Messages Mirror active"
+        val channel = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_LOW).let {
             it.setShowBadge(false)
             it
         }
@@ -177,7 +130,7 @@ class NtfySmsReceiverService : Service() {
     }
 
     override fun onDestroy() {
-        unregisterReceiver(messageReceiver)
+        unregisterReceiver(eventReceiver)
         sendBroadcast(Intent(this, AutoRestartReceiver::class.java)) // Restart if necessary
         super.onDestroy()
     }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
@@ -53,7 +53,7 @@ class EventConsumerService : Service() {
             val isEnabled = prefs.getBoolean(MirrorSettingsView.Companion.ENABLE_NAME, false)
             val subscribedTopic = prefs.getString(MirrorSettingsView.Companion.TOPIC_NAME, "")
             val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() }
-                ?: throw IllegalStateException("Device ID is null or empty")
+                ?: error("Device ID is null or empty")
             val topic = intent.getStringExtra(ForwardingSmsReceiver.Companion.NTFY_TOPIC)
 
             if (!isEnabled || topic != subscribedTopic)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/ServiceManager.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/ServiceManager.kt
@@ -27,7 +27,7 @@ class ServiceManager(private val context: Context) {
             }
 
             withContext(Dispatchers.IO) {
-                Intent(context, NtfySmsReceiverService::class.java).also {
+                Intent(context, EventConsumerService::class.java).also {
                     ContextCompat.startForegroundService(context, it)
                 }
             }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/views/MirrorSettingsView.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/views/MirrorSettingsView.kt
@@ -20,7 +20,8 @@ import com.journeyapps.barcodescanner.ScanIntentResult
 import com.journeyapps.barcodescanner.ScanOptions
 import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.dialogs.ShareMirrorSettingsDialog
-import org.cpardi.messagemirror.helpers.SETTINGS_NAME
+import org.cpardi.messagemirror.helpers.Constants
+import org.cpardi.messagemirror.models.DeviceMode
 import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver
 import org.fossify.commons.compose.extensions.getActivity
 import org.fossify.commons.dialogs.RadioGroupDialog
@@ -41,30 +42,14 @@ class MirrorSettingsView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs, defStyleAttr) {
 
     private val binding = ViewMirrorSettingsBinding.inflate(LayoutInflater.from(context), this)
-    private val prefs: SharedPreferences = context.getSharedPreferences(SETTINGS_NAME, Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = context.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE)
     private val editPrefs: SharedPreferences.Editor = prefs.edit()
     private val barcodeLauncher = (context as? ComponentActivity)?.registerForActivityResult(ScanContract()) { result -> handleBarcodeContent(result, context) }
 
     companion object {
-        const val MODE_NAME = "mode"
         const val ENABLE_NAME = "mirror_enabled"
         const val TOPIC_NAME = "topic_name"
         const val ENCRYPTION_KEY_NAME = "encryption_key"
-    }
-
-    enum class DeviceMode(val value: Int) {
-        SmsHost(1),
-        Mirror(2);
-
-        fun description(): String = when (this) {
-            SmsHost -> "SMS Host"
-            Mirror -> "Mirror"
-        }
-
-        companion object {
-            fun fromInt(value: Int): DeviceMode = entries.find { it.value == value }
-                ?: throw IllegalArgumentException("Invalid Mode value: $value")
-        }
     }
 
     init {
@@ -119,16 +104,16 @@ class MirrorSettingsView @JvmOverloads constructor(
     }
 
     private fun setupDeviceMode() = binding.apply {
-        val currentMode = DeviceMode.fromInt(prefs.getInt(MODE_NAME, DeviceMode.SmsHost.value))
+        val currentMode = DeviceMode.fromInt(prefs.getInt(Constants.MODE_NAME, DeviceMode.SmsHost.value))
         mirrorSettingsMode.text = currentMode.description()
 
         mirrorSettingsModeHolder.setOnClickListener {
             val items = DeviceMode.entries.map { id -> RadioItem(id.value, id.description()) }.toArrayList()
-            val currentMode = DeviceMode.fromInt(prefs.getInt(MODE_NAME, DeviceMode.SmsHost.value))
+            val currentMode = DeviceMode.fromInt(prefs.getInt(Constants.MODE_NAME, DeviceMode.SmsHost.value))
             RadioGroupDialog(context.getActivity(), items, currentMode.value) { selected ->
                 val mode = DeviceMode.fromInt(selected as Int)
                 mirrorSettingsMode.text = mode.description()
-                editPrefs.putInt(MODE_NAME, selected).apply()
+                editPrefs.putInt(Constants.MODE_NAME, selected).apply()
             }
         }
     }

--- a/app/src/main/kotlin/org/fossify/messages/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/MainActivity.kt
@@ -2,6 +2,7 @@ package org.fossify.messages.activities
 
 import android.annotation.SuppressLint
 import android.app.role.RoleManager
+import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
@@ -11,10 +12,7 @@ import android.os.Bundle
 import android.provider.Telephony
 import android.text.TextUtils
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.PeriodicWorkRequest
-import androidx.work.WorkManager
+import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.services.ServiceManager
 import org.fossify.commons.dialogs.PermissionRequiredDialog
 import org.fossify.commons.extensions.adjustAlpha
@@ -78,6 +76,7 @@ import org.fossify.messages.models.SearchResult
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import java.util.UUID
 
 class MainActivity : SimpleActivity() {
     override var isSearchBarEnabled = true
@@ -290,10 +289,16 @@ class MainActivity : SimpleActivity() {
             launchNewConversation()
         }
 
-        startNtfySmsService()
+        initMessagesMirror()
     }
 
-    private fun startNtfySmsService() {
+    private fun initMessagesMirror() {
+        val preferences = application.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE)
+        if(!preferences.contains(Constants.DEVICE_ID_NAME)) {
+            val uniqueID = UUID.randomUUID().toString()
+            preferences.edit().putString(Constants.DEVICE_ID_NAME, uniqueID).apply()
+        }
+
         ServiceManager(applicationContext).refresh();
     }
 

--- a/app/src/main/kotlin/org/fossify/messages/messaging/ISmsSender.kt
+++ b/app/src/main/kotlin/org/fossify/messages/messaging/ISmsSender.kt
@@ -1,0 +1,10 @@
+package org.fossify.messages.messaging
+
+import android.net.Uri
+import org.cpardi.messagemirror.models.DeviceMode
+
+interface ISmsSender {
+    val forMode: DeviceMode
+
+    fun sendMessage(subId: Int, destination: String, body: String, serviceCenter: String?, requireDeliveryReport: Boolean, messageUri: Uri)
+}

--- a/app/src/main/kotlin/org/fossify/messages/messaging/Messaging.kt
+++ b/app/src/main/kotlin/org/fossify/messages/messaging/Messaging.kt
@@ -49,7 +49,8 @@ fun Context.sendMessageCompat(
     messageId: Long? = null
 ) {
     val prefs = this.getSharedPreferences(Constants.SETTINGS_NAME, MODE_PRIVATE)
-    val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() } ?: throw IllegalStateException("Device ID is null or empty")
+    val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() }
+        ?: error("Device ID is null or empty")
     val metadata = EventMetadataDto(deviceID)
     val dto: EventDto = EventDto.SmsSend(metadata, text, addresses, subId, attachments.map { attachment -> attachment.toDto() }, messageId)
     broadcastEvent(prefs, dto)

--- a/app/src/main/kotlin/org/fossify/messages/messaging/Messaging.kt
+++ b/app/src/main/kotlin/org/fossify/messages/messaging/Messaging.kt
@@ -1,10 +1,16 @@
 package org.fossify.messages.messaging
 
 import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import android.telephony.SmsMessage
 import android.util.Patterns
 import android.widget.Toast.LENGTH_LONG
 import com.klinker.android.send_message.Settings
+import org.cpardi.messagemirror.extensions.broadcastEvent
+import org.cpardi.messagemirror.helpers.Constants
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.EventMetadataDto
+import org.cpardi.messagemirror.models.toDto
 import org.fossify.commons.extensions.showErrorToast
 import org.fossify.commons.extensions.toast
 import org.fossify.commons.helpers.ensureBackgroundThread
@@ -35,8 +41,23 @@ fun Context.isLongMmsMessage(text: String, settings: Settings = getSendMessageSe
     return numPages > settings.sendLongAsMmsAfter && settings.sendLongAsMms
 }
 
-/** Sends the message using the in-app SmsManager API wrappers if it's an SMS or using android-smsmms for MMS. */
 fun Context.sendMessageCompat(
+    text: String,
+    addresses: List<String>,
+    subId: Int?,
+    attachments: List<Attachment>,
+    messageId: Long? = null
+) {
+    val prefs = this.getSharedPreferences(Constants.SETTINGS_NAME, MODE_PRIVATE)
+    val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() } ?: throw IllegalStateException("Device ID is null or empty")
+    val metadata = EventMetadataDto(deviceID)
+    val dto: EventDto = EventDto.SmsSend(metadata, text, addresses, subId, attachments.map { attachment -> attachment.toDto() }, messageId)
+    broadcastEvent(prefs, dto)
+    sendMessageOnDeviceCompat(text, addresses, subId, attachments, messageId)
+}
+
+/** Sends the message using the in-app SmsManager API wrappers if it's an SMS or using android-smsmms for MMS. */
+fun Context.sendMessageOnDeviceCompat(
     text: String,
     addresses: List<String>,
     subId: Int?,

--- a/app/src/main/kotlin/org/fossify/messages/messaging/NullSmsSender.kt
+++ b/app/src/main/kotlin/org/fossify/messages/messaging/NullSmsSender.kt
@@ -1,0 +1,12 @@
+package org.fossify.messages.messaging
+
+import android.net.Uri
+import org.cpardi.messagemirror.models.DeviceMode
+
+class NullSmsSender : ISmsSender{
+    override val forMode = DeviceMode.Mirror
+
+    override fun sendMessage(subId: Int, destination: String, body: String, serviceCenter: String?, requireDeliveryReport: Boolean, messageUri: Uri) {
+        // Intentionally empty
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/messaging/SmsSender.kt
+++ b/app/src/main/kotlin/org/fossify/messages/messaging/SmsSender.kt
@@ -2,9 +2,12 @@ package org.fossify.messages.messaging
 
 import android.app.Application
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.telephony.PhoneNumberUtils
+import org.cpardi.messagemirror.helpers.Constants
+import org.cpardi.messagemirror.models.DeviceMode
 import org.fossify.commons.helpers.isSPlus
 import org.fossify.messages.messaging.SmsException.Companion.EMPTY_DESTINATION_ADDRESS
 import org.fossify.messages.messaging.SmsException.Companion.ERROR_SENDING_MESSAGE
@@ -13,13 +16,15 @@ import org.fossify.messages.receivers.SmsStatusDeliveredReceiver
 import org.fossify.messages.receivers.SmsStatusSentReceiver
 
 /** Class that sends chat message via SMS. */
-class SmsSender(val app: Application) {
+class SmsSender(val app: Application): ISmsSender {
 
     // not sure what to do about this yet. this is the default as per android-smsmms
     private val sendMultipartSmsAsSeparateMessages = false
 
+    override val forMode = DeviceMode.Mirror
+
     // This should be called from a RequestWriter queue thread
-    fun sendMessage(
+    override fun sendMessage(
         subId: Int, destination: String, body: String, serviceCenter: String?,
         requireDeliveryReport: Boolean, messageUri: Uri
     ) {
@@ -122,10 +127,17 @@ class SmsSender(val app: Application) {
     }
 
     companion object {
-        private var instance: SmsSender? = null
-        fun getInstance(app: Application): SmsSender {
-            if (instance == null) {
-                instance = SmsSender(app)
+        private var instance: ISmsSender? = null
+        fun getInstance(app: Application): ISmsSender {
+            val mode = app.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE).getInt(Constants.MODE_NAME, -1)
+            val deviceMode = DeviceMode.fromInt(mode)
+
+            if (deviceMode != instance?.forMode) {
+                instance = when(deviceMode) {
+                    DeviceMode.SmsHost -> SmsSender(app)
+                    DeviceMode.Mirror -> NullSmsSender()
+                    else -> throw NoWhenBranchMatchedException("Device mode case isn't implemented")
+                }
             }
             return instance!!
         }


### PR DESCRIPTION
## Behaviour

- SMS messages sent from the mirror will be passed to the SMS host to send.
- The following behaviours are added so that what is displayed on the SMS host is the same as what is on the mirror.
  - SMS messages sent from the SMS host will be display by the mirror.
  - SMS messages received by the mirror will be displayed on the SMS host.

## Implementation

- Introduced ISmsSender interface and implementations for device modes. Only SMS Hosts will send SMS messages.
- Introduced SmsReceiveHandler and SmsSendHandler for handling SMS events
- Updated MainActivity to initialize device ID to be used to ignore message consumed by the device that sent it

## Refactored

- Added Context.broadcastEvent extension to broadcast messages to ntfy.sh
- Renamed NtfySmsReceiverService to EventConsumerService
- Moved several constant to separate Constants.kt file