### PR TITLE
Implement forwarding of SMS send status events

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ While the Messages Mirror app provides core functionality for SMS mirroring, som
 | Operation                                           | Status          | Notes                                         |
 |-----------------------------------------------------|-----------------|-----------------------------------------------|
 | MMS Receiving (`MmsReceiver`)                       | Not implemented | MMS messages are not yet mirrored.            |
-| SMS Sent Status (`SmsStatusSentReceiver`)           | Not implemented | Sent message status updates are not mirrored. |
-| SMS Delivered Status (`SmsStatusDeliveredReceiver`) | Not implemented | Delivery reports are not mirrored.            |
-| MMS Sent Status (`MmsSentReceiver`)                 | Not implemented | MMS sent status updates are not mirrored.     |
 | Scheduled Messages (`ScheduledMessageReceiver`)     | Not implemented | Scheduled message sending is not mirrored.    |
 | Message Deletion (`DeleteSmsReceiver`)              | Not implemented | Message deletions are not mirrored.           |
 | Direct Reply (`DirectReplyReceiver`)                | Not implemented | Inline reply handling is not mirrored.        |

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
@@ -2,8 +2,8 @@ package org.cpardi.messagemirror.extensions
 
 import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
 import android.util.Base64
+import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver.Companion.NTFY_MESSAGE
@@ -14,7 +14,8 @@ import org.cpardi.messagemirror.views.MirrorSettingsView
 import org.fossify.commons.helpers.ensureBackgroundThread
 import javax.crypto.spec.SecretKeySpec
 
-fun Context.broadcastEvent(prefs: SharedPreferences, dto: EventDto) {
+fun Context.broadcastEvent(dto: EventDto) {
+    val prefs = this.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE)
     val topic = prefs.getString(MirrorSettingsView.Companion.TOPIC_NAME, "")
     val keyBase64 = prefs.getString(MirrorSettingsView.ENCRYPTION_KEY_NAME, null)
     val keyBytes = Base64.decode(keyBase64, Base64.NO_WRAP)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsSendStatusHandler.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsSendStatusHandler.kt
@@ -1,0 +1,23 @@
+package org.cpardi.messagemirror.helpers
+
+import android.content.Context
+import android.content.Intent
+import android.os.Parcel
+import org.cpardi.messagemirror.models.EventDto
+
+class SmsSendStatusHandler(val deviceID: String) {
+    fun handle(context: Context, dto: EventDto.SmsSendStatus) {
+        if (deviceID == dto.metadata.senderID)
+            return
+
+        val parcel = Parcel.obtain()
+        try {
+            parcel.unmarshall(dto.intentParcel.toByteArray(), 0, dto.intentParcel.size)
+            parcel.setDataPosition(0)
+            val intent = Intent.CREATOR.createFromParcel(parcel)
+            context.sendBroadcast(intent)
+        } finally {
+            parcel.recycle()
+        }
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
@@ -31,6 +31,13 @@ sealed class EventDto {
         val messageId: Long?
     ) : EventDto()
 
+    /** Represents when an SMS message is sent by a Mirror */
+    @Serializable
+    data class SmsSendStatus(
+        val metadata: EventMetadataDto,
+        val intentParcel: List<Byte>
+    ) : EventDto()
+
     companion object {
         /** Enables polymorphic serialisation for this class */
         val Serializer: Json
@@ -39,6 +46,7 @@ sealed class EventDto {
                     polymorphic(EventDto::class) {
                         subclass(SmsReceive::class)
                         subclass(SmsSend::class)
+                        subclass(SmsSendStatus::class)
                     }
                 }
                 classDiscriminator = "type"

--- a/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
@@ -51,7 +51,7 @@ class ForwardingSmsReceiver(private val wrappedReceiver: SmsReceiver = SmsReceiv
                 ?: error("Device ID is null or empty")
             val metadata = EventMetadataDto(deviceID)
             val dto: EventDto = EventDto.SmsReceive(metadata, address, subject, status, body, date)
-            context.broadcastEvent(prefs, dto)
+            context.broadcastEvent(dto)
         }
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
@@ -19,6 +19,7 @@ import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.helpers.SmsReceiveHandler
 import org.cpardi.messagemirror.helpers.SmsSendHandler
+import org.cpardi.messagemirror.helpers.SmsSendStatusHandler
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver
 import org.cpardi.messagemirror.views.MirrorSettingsView
@@ -86,6 +87,7 @@ class EventConsumerService : Service() {
             when (dto) {
                 is EventDto.SmsReceive -> SmsReceiveHandler(deviceID).handle(subscriptionId, context, dto)
                 is EventDto.SmsSend -> SmsSendHandler(deviceID).handle(context, dto)
+                is EventDto.SmsSendStatus -> SmsSendStatusHandler(deviceID).handle(context, dto)
                 else -> return
             }
         }

--- a/app/src/main/kotlin/org/fossify/messages/messaging/Messaging.kt
+++ b/app/src/main/kotlin/org/fossify/messages/messaging/Messaging.kt
@@ -53,7 +53,7 @@ fun Context.sendMessageCompat(
         ?: error("Device ID is null or empty")
     val metadata = EventMetadataDto(deviceID)
     val dto: EventDto = EventDto.SmsSend(metadata, text, addresses, subId, attachments.map { attachment -> attachment.toDto() }, messageId)
-    broadcastEvent(prefs, dto)
+    broadcastEvent(dto)
     sendMessageOnDeviceCompat(text, addresses, subId, attachments, messageId)
 }
 

--- a/app/src/main/kotlin/org/fossify/messages/receivers/ForwardingSendStatusReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/ForwardingSendStatusReceiver.kt
@@ -1,0 +1,36 @@
+package org.fossify.messages.receivers
+
+import android.content.Context
+import android.content.Intent
+import android.os.Parcel
+import org.cpardi.messagemirror.extensions.broadcastEvent
+import org.cpardi.messagemirror.helpers.Constants
+import org.cpardi.messagemirror.models.DeviceMode
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.EventMetadataDto
+
+abstract class ForwardingSendStatusReceiver : SendStatusReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val prefs = context.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE)
+        val mode = DeviceMode.Companion.fromInt(prefs.getInt(Constants.MODE_NAME, -1))
+
+        if (mode == DeviceMode.SmsHost) {
+            val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "")
+                .takeIf { !it.isNullOrEmpty() } ?: error("Device ID is null or empty")
+            val parcel = Parcel.obtain()
+            try {
+                intent.writeToParcel(parcel, 0)
+                val parcelBytes = parcel.marshall().toList()
+                val metadata = EventMetadataDto(deviceID)
+                val dto = EventDto.SmsSendStatus(metadata, parcelBytes)
+                context.broadcastEvent(dto)
+
+            } finally {
+                parcel.recycle()
+            }
+        }
+
+        super.onReceive(context, intent)
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/receivers/MmsSentReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/MmsSentReceiver.kt
@@ -17,7 +17,7 @@ import org.fossify.messages.helpers.refreshMessages
 import java.io.File
 
 /** Handles updating databases and states when a MMS message is sent. */
-class MmsSentReceiver : SendStatusReceiver() {
+class MmsSentReceiver : ForwardingSendStatusReceiver() {
 
     override fun updateAndroidDatabase(context: Context, intent: Intent, receiverResultCode: Int) {
         val uri = Uri.parse(intent.getStringExtra(EXTRA_CONTENT_URI))

--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusDeliveredReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusDeliveredReceiver.kt
@@ -12,7 +12,7 @@ import org.fossify.messages.extensions.messagingUtils
 import org.fossify.messages.helpers.refreshMessages
 
 /** Handles updating databases and states when a sent SMS message is delivered. */
-class SmsStatusDeliveredReceiver : SendStatusReceiver() {
+class SmsStatusDeliveredReceiver : ForwardingSendStatusReceiver() {
 
     private var status: Int = Sms.Sent.STATUS_NONE
 

--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusSentReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusSentReceiver.kt
@@ -21,7 +21,7 @@ import org.fossify.messages.helpers.refreshConversations
 import org.fossify.messages.helpers.refreshMessages
 
 /** Handles updating databases and states when a SMS message is sent. */
-class SmsStatusSentReceiver : SendStatusReceiver() {
+class SmsStatusSentReceiver : ForwardingSendStatusReceiver() {
 
     override fun updateAndroidDatabase(context: Context, intent: Intent, receiverResultCode: Int) {
         val messageUri: Uri? = intent.data


### PR DESCRIPTION
## Behaviour

- Sending a message on an SMS host will update send and delivered status' on the mirror
- Sending a message on a Mirror will update send and delivered status' once update on the SMS host

## Implementation

- Added a ForwardingSendStatusReceiver and updated MmsSentReceiver, SmsStatusDeliveredReceiver and SmsStatusSentReceiver to inherit this class. This class broadcasts events for the various status' to the Mirror.
- Added a SmsSendStatusHandler to EventConsumerService.kt which recreate the Intent from the byte list and broadcast it on the Mirror.

## Refactor

- Remove pref from broadcastEvent arg list