### PR TITLE
Refactor ForwardingSmsReceiver and SmsReceiveHandler to use Parcels

### DIFF
--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -27,7 +27,7 @@
     <ID>FunctionParameterNaming:Config.kt$Config$SIMId: Int</ID>
     <ID>LargeClass:ThreadActivity.kt$ThreadActivity : SimpleActivity</ID>
     <ID>LongMethod:NotificationHelper.kt$NotificationHelper$@SuppressLint("NewApi") fun showMessageNotification( messageId: Long, address: String, body: String, threadId: Long, bitmap: Bitmap?, sender: String?, alertOnlyOnce: Boolean = false )</ID>
-    <ID>LongParameterList:SmsReceiver.kt$SmsReceiver.Companion$( context: Context, address: String, subject: String, body: String, date: Long, read: Int, threadId: Long, type: Int, subscriptionId: Int, status: Int )</ID>
+    <ID>LongParameterList:SmsReceiver.kt$SmsReceiver$( context: Context, address: String, subject: String, body: String, date: Long, read: Int, threadId: Long, type: Int, subscriptionId: Int, status: Int )</ID>
     <ID>MagicNumber:Activity.kt$1000000</ID>
     <ID>MagicNumber:BaseConversationsAdapter.kt$BaseConversationsAdapter$0.7f</ID>
     <ID>MagicNumber:BaseConversationsAdapter.kt$BaseConversationsAdapter$0.8f</ID>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -223,6 +223,11 @@
                 <action android:name="android.provider.Telephony.SMS_DELIVER" />
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name="org.cpardi.messagemirror.receivers.RemoteSmsReceiver"
+            android:exported="false">
+        </receiver>
         <!-- end org.cpardi.messagemirror  -->
 
         <receiver

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
@@ -3,6 +3,7 @@ package org.cpardi.messagemirror.extensions
 import android.content.Context
 import android.content.Intent
 import android.util.Base64
+import android.util.Log
 import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.models.EventDto
@@ -13,6 +14,7 @@ import org.cpardi.messagemirror.receivers.ForwardingSmsReceiver.Companion.NTFY_T
 import org.cpardi.messagemirror.views.MirrorSettingsView
 import org.fossify.commons.helpers.ensureBackgroundThread
 import javax.crypto.spec.SecretKeySpec
+import kotlin.math.log
 
 fun Context.broadcastEvent(dto: EventDto) {
     val prefs = this.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Serialization.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Serialization.kt
@@ -1,0 +1,27 @@
+package org.cpardi.messagemirror.extensions
+
+import android.content.Intent
+import android.os.Parcel
+
+fun ByteArray.toIntent(): Intent {
+    val parcel = Parcel.obtain()
+    try {
+        parcel.unmarshall(this, 0, this.size)
+        parcel.setDataPosition(0)
+        return Intent.CREATOR.createFromParcel(parcel)
+    } finally {
+        parcel.recycle()
+    }
+}
+
+fun Intent.toByteArray(): ByteArray {
+    val parcel = Parcel.obtain()
+    try {
+        this.writeToParcel(parcel, 0)
+        val parcelBytes = parcel.marshall()
+        return parcelBytes
+
+    } finally {
+        parcel.recycle()
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsReceiveHandler.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsReceiveHandler.kt
@@ -1,63 +1,25 @@
 package org.cpardi.messagemirror.helpers
 
+import android.content.ComponentName
 import android.content.Context
-import android.provider.Telephony
+import android.util.Log
+import org.cpardi.messagemirror.extensions.broadcastEvent
+import org.cpardi.messagemirror.extensions.toIntent
 import org.cpardi.messagemirror.models.EventDto
-import org.fossify.commons.extensions.baseConfig
-import org.fossify.commons.extensions.getMyContactsCursor
-import org.fossify.commons.helpers.SimpleContactsHelper
-import org.fossify.commons.helpers.ensureBackgroundThread
-import org.fossify.messages.extensions.getThreadId
-import org.fossify.messages.receivers.SmsReceiver
+import org.cpardi.messagemirror.receivers.RemoteSmsReceiver
 
 class SmsReceiveHandler(val deviceID: String) {
-    fun handle(subscriptionId: Int, context: Context, dto: EventDto.SmsReceive) {
-        if (deviceID == dto.metadata.senderID)
+
+    fun handle(context: Context, dto: EventDto.SmsReceive) {
+        if (deviceID == dto.metadata.senderID) {
+            Log.d(Context::broadcastEvent.name, "Ignored remote SMS Receive message on device $deviceID")
             return
-
-        val address = dto.address
-        val body = dto.body
-        val subject = dto.subject
-        val date = System.currentTimeMillis()
-        val threadId = context.getThreadId(address)
-        val status = Telephony.Sms.STATUS_NONE
-        val type = Telephony.Sms.MESSAGE_TYPE_INBOX
-        val read = 0
-
-        val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
-        ensureBackgroundThread {
-            if (context.baseConfig.blockUnknownNumbers) {
-                val simpleContactsHelper = SimpleContactsHelper(context)
-                simpleContactsHelper.exists(address, privateCursor) { exists ->
-                    if (exists) {
-                        SmsReceiver.Companion.handleMessage(
-                            context,
-                            address,
-                            subject,
-                            body,
-                            date,
-                            read,
-                            threadId,
-                            type,
-                            subscriptionId,
-                            status
-                        )
-                    }
-                }
-            } else {
-                SmsReceiver.Companion.handleMessage(
-                    context,
-                    address,
-                    subject,
-                    body,
-                    date,
-                    read,
-                    threadId,
-                    type,
-                    subscriptionId,
-                    status
-                )
-            }
         }
+
+        val intent = dto.intentBytes.toByteArray().toIntent()
+        intent.action = RemoteSmsReceiver::class.java.name
+        intent.component = ComponentName(context, RemoteSmsReceiver::class.java)
+        context.sendBroadcast(intent)
+        Log.d(Context::broadcastEvent.name, "Broadcast remote SMS Receive message on device $deviceID")
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsSendStatusHandler.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/SmsSendStatusHandler.kt
@@ -3,6 +3,7 @@ package org.cpardi.messagemirror.helpers
 import android.content.Context
 import android.content.Intent
 import android.os.Parcel
+import org.cpardi.messagemirror.extensions.toIntent
 import org.cpardi.messagemirror.models.EventDto
 
 class SmsSendStatusHandler(val deviceID: String) {
@@ -10,14 +11,7 @@ class SmsSendStatusHandler(val deviceID: String) {
         if (deviceID == dto.metadata.senderID)
             return
 
-        val parcel = Parcel.obtain()
-        try {
-            parcel.unmarshall(dto.intentParcel.toByteArray(), 0, dto.intentParcel.size)
-            parcel.setDataPosition(0)
-            val intent = Intent.CREATOR.createFromParcel(parcel)
-            context.sendBroadcast(intent)
-        } finally {
-            parcel.recycle()
-        }
+        val intent = dto.intentParcel.toByteArray().toIntent()
+        context.sendBroadcast(intent)
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
@@ -13,11 +13,7 @@ sealed class EventDto {
     @Serializable
     data class SmsReceive(
         val metadata: EventMetadataDto,
-        val address: String,
-        val subject: String,
-        val status: Int,
-        val body: String,
-        val date: Long
+        val intentBytes: List<Byte>
     ) : EventDto()
 
     /** Represents when an SMS message is sent by a Mirror */

--- a/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSendStatusReceiver.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSendStatusReceiver.kt
@@ -1,13 +1,14 @@
-package org.fossify.messages.receivers
+package org.cpardi.messagemirror.receivers
 
 import android.content.Context
 import android.content.Intent
-import android.os.Parcel
 import org.cpardi.messagemirror.extensions.broadcastEvent
+import org.cpardi.messagemirror.extensions.toByteArray
 import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.models.DeviceMode
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.models.EventMetadataDto
+import org.fossify.messages.receivers.SendStatusReceiver
 
 abstract class ForwardingSendStatusReceiver : SendStatusReceiver() {
 
@@ -18,17 +19,10 @@ abstract class ForwardingSendStatusReceiver : SendStatusReceiver() {
         if (mode == DeviceMode.SmsHost) {
             val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "")
                 .takeIf { !it.isNullOrEmpty() } ?: error("Device ID is null or empty")
-            val parcel = Parcel.obtain()
-            try {
-                intent.writeToParcel(parcel, 0)
-                val parcelBytes = parcel.marshall().toList()
-                val metadata = EventMetadataDto(deviceID)
-                val dto = EventDto.SmsSendStatus(metadata, parcelBytes)
-                context.broadcastEvent(dto)
-
-            } finally {
-                parcel.recycle()
-            }
+            val intentByteArray = intent.toByteArray().toList()
+            val metadata = EventMetadataDto(deviceID)
+            val dto = EventDto.SmsSendStatus(metadata, intentByteArray)
+            context.broadcastEvent(dto)
         }
 
         super.onReceive(context, intent)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSmsReceiver.kt
@@ -3,13 +3,12 @@ package org.cpardi.messagemirror.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.provider.Telephony
+import android.util.Log
 import org.cpardi.messagemirror.extensions.broadcastEvent
+import org.cpardi.messagemirror.extensions.toByteArray
 import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.models.EventMetadataDto
-import org.cpardi.messagemirror.views.MirrorSettingsView
-import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.messages.receivers.SmsReceiver
 
 class ForwardingSmsReceiver(private val wrappedReceiver: SmsReceiver = SmsReceiver()) :
@@ -25,33 +24,16 @@ class ForwardingSmsReceiver(private val wrappedReceiver: SmsReceiver = SmsReceiv
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != SMS_DELIVER_ACTION) return
 
-        wrappedReceiver.onReceive(context, intent)
         val prefs = context.getSharedPreferences(Constants.SETTINGS_NAME, Context.MODE_PRIVATE)
-        val isEnabled = prefs.getBoolean(MirrorSettingsView.ENABLE_NAME, false)
+        val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() }
+            ?: error("Device ID is null or empty")
 
-        if (!isEnabled) return
+        val intentBytes = intent.toByteArray().toList()
+        val metadata = EventMetadataDto(deviceID)
+        val dto: EventDto = EventDto.SmsReceive(metadata, intentBytes)
+        context.broadcastEvent(dto)
+        Log.d(Context::broadcastEvent.name, "Sent ntfy from device $deviceID")
 
-        val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
-        var address = ""
-        var body = ""
-        var subject = ""
-        var date = 0L
-        var status = Telephony.Sms.STATUS_NONE
-
-        ensureBackgroundThread {
-            messages.forEach {
-                address = it.originatingAddress ?: ""
-                subject = it.pseudoSubject
-                status = it.status
-                body += it.messageBody
-                date = System.currentTimeMillis()
-            }
-
-            val deviceID = prefs.getString(Constants.DEVICE_ID_NAME, "").takeIf { !it.isNullOrEmpty() }
-                ?: error("Device ID is null or empty")
-            val metadata = EventMetadataDto(deviceID)
-            val dto: EventDto = EventDto.SmsReceive(metadata, address, subject, status, body, date)
-            context.broadcastEvent(dto)
-        }
+        wrappedReceiver.onReceive(context, intent)
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/receivers/RemoteSmsReceiver.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/receivers/RemoteSmsReceiver.kt
@@ -1,0 +1,5 @@
+package org.cpardi.messagemirror.receivers
+
+import org.fossify.messages.receivers.SmsReceiver
+
+class RemoteSmsReceiver : SmsReceiver()

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
@@ -82,10 +82,9 @@ class EventConsumerService : Service() {
                 }
             }
 
-            val subscriptionId = intent.getIntExtra("subscription", -1)
             val dto = EventDto.Companion.Serializer.decodeFromString<EventDto>(decryptedMessage)
             when (dto) {
-                is EventDto.SmsReceive -> SmsReceiveHandler(deviceID).handle(subscriptionId, context, dto)
+                is EventDto.SmsReceive -> SmsReceiveHandler(deviceID).handle(context, dto)
                 is EventDto.SmsSend -> SmsSendHandler(deviceID).handle(context, dto)
                 is EventDto.SmsSendStatus -> SmsSendStatusHandler(deviceID).handle(context, dto)
                 else -> return

--- a/app/src/main/kotlin/org/fossify/messages/receivers/MmsSentReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/MmsSentReceiver.kt
@@ -8,6 +8,7 @@ import android.database.sqlite.SQLiteException
 import android.net.Uri
 import android.provider.Telephony
 import android.widget.Toast
+import org.cpardi.messagemirror.receivers.ForwardingSendStatusReceiver
 import org.fossify.commons.extensions.showErrorToast
 import org.fossify.commons.extensions.toast
 import org.fossify.messages.R

--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
@@ -28,7 +28,7 @@ import org.fossify.messages.helpers.refreshConversations
 import org.fossify.messages.helpers.refreshMessages
 import org.fossify.messages.models.Message
 
-class SmsReceiver : BroadcastReceiver() {
+open class SmsReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
         var address = ""
@@ -64,68 +64,66 @@ class SmsReceiver : BroadcastReceiver() {
         }
     }
 
-    companion object {
-        fun handleMessage(
-            context: Context,
-            address: String,
-            subject: String,
-            body: String,
-            date: Long,
-            read: Int,
-            threadId: Long,
-            type: Int,
-            subscriptionId: Int,
-            status: Int
-        ) {
-            if (isMessageFilteredOut(context, body)) {
-                return
-            }
+    private fun handleMessage(
+        context: Context,
+        address: String,
+        subject: String,
+        body: String,
+        date: Long,
+        read: Int,
+        threadId: Long,
+        type: Int,
+        subscriptionId: Int,
+        status: Int
+    ) {
+        if (isMessageFilteredOut(context, body)) {
+            return
+        }
 
-            val photoUri = SimpleContactsHelper(context).getPhotoUriFromPhoneNumber(address)
-            val bitmap = context.getNotificationBitmap(photoUri)
-            Handler(Looper.getMainLooper()).post {
-                if (!context.isNumberBlocked(address)) {
-                    val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
-                    ensureBackgroundThread {
-                        val newMessageId = context.insertNewSMS(address, subject, body, date, read, threadId, type, subscriptionId)
+        val photoUri = SimpleContactsHelper(context).getPhotoUriFromPhoneNumber(address)
+        val bitmap = context.getNotificationBitmap(photoUri)
+        Handler(Looper.getMainLooper()).post {
+            if (!context.isNumberBlocked(address)) {
+                val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
+                ensureBackgroundThread {
+                    val newMessageId = context.insertNewSMS(address, subject, body, date, read, threadId, type, subscriptionId)
 
-                        val conversation = context.getConversations(threadId).firstOrNull() ?: return@ensureBackgroundThread
-                        try {
-                            context.insertOrUpdateConversation(conversation)
-                        } catch (ignored: Exception) {
-                        }
-
-                        val senderName = context.getNameFromAddress(address, privateCursor)
-                        val phoneNumber = PhoneNumber(address, 0, "", address)
-                        val participant = SimpleContact(0, 0, senderName, photoUri, arrayListOf(phoneNumber), ArrayList(), ArrayList())
-                        val participants = arrayListOf(participant)
-                        val messageDate = (date / 1000).toInt()
-
-                        val message =
-                            Message(
-                                newMessageId,
-                                body,
-                                type,
-                                status,
-                                participants,
-                                messageDate,
-                                false,
-                                threadId,
-                                false,
-                                null,
-                                address,
-                                senderName,
-                                photoUri,
-                                subscriptionId
-                            )
-                        context.messagesDB.insertOrUpdate(message)
-                        if (context.shouldUnarchive()) {
-                            context.updateConversationArchivedStatus(threadId, false)
-                        }
-                        refreshMessages()
-                        refreshConversations()
-                        context.showReceivedMessageNotification(newMessageId, address, body, threadId, bitmap)
+                    val conversation = context.getConversations(threadId).firstOrNull() ?: return@ensureBackgroundThread
+                    try {
+                        context.insertOrUpdateConversation(conversation)
+                    } catch (ignored: Exception) {
                     }
+
+                    val senderName = context.getNameFromAddress(address, privateCursor)
+                    val phoneNumber = PhoneNumber(address, 0, "", address)
+                    val participant = SimpleContact(0, 0, senderName, photoUri, arrayListOf(phoneNumber), ArrayList(), ArrayList())
+                    val participants = arrayListOf(participant)
+                    val messageDate = (date / 1000).toInt()
+
+                    val message =
+                        Message(
+                            newMessageId,
+                            body,
+                            type,
+                            status,
+                            participants,
+                            messageDate,
+                            false,
+                            threadId,
+                            false,
+                            null,
+                            address,
+                            senderName,
+                            photoUri,
+                            subscriptionId
+                        )
+                    context.messagesDB.insertOrUpdate(message)
+                    if (context.shouldUnarchive()) {
+                        context.updateConversationArchivedStatus(threadId, false)
+                    }
+                    refreshMessages()
+                    refreshConversations()
+                    context.showReceivedMessageNotification(newMessageId, address, body, threadId, bitmap)
                 }
             }
         }

--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusDeliveredReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusDeliveredReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.Telephony.Sms
+import org.cpardi.messagemirror.receivers.ForwardingSendStatusReceiver
 import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.messages.extensions.messagesDB
 import org.fossify.messages.extensions.messagingUtils

--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusSentReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsStatusSentReceiver.kt
@@ -9,6 +9,7 @@ import android.os.Looper
 import android.provider.Telephony.Sms
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
+import org.cpardi.messagemirror.receivers.ForwardingSendStatusReceiver
 import org.fossify.commons.extensions.getMyContactsCursor
 import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.messages.extensions.getMessageRecipientAddress


### PR DESCRIPTION
Using parcels similar to SmsSendStatusHandler Removes code duplicated from original project in ForwardingSmsReceiver and SmsReceiveHandler.

Has the disadvantage of making messages larger. Could add compression https://github.com/CPardi/Messages-Mirror/issues/34#issue-3745797775