### PR TITLE
Support mirroring SMS deletions

### DIFF
--- a/app/src/main/kotlin/org/cpardi/messagemirror/databases/MessageMapDao.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/databases/MessageMapDao.kt
@@ -19,6 +19,9 @@ interface MessageMapDao {
 
     @Query("SELECT * FROM MessageMapStateEntity WHERE localMsgId = :localMsgId LIMIT 1")
     fun getByLocalMsgId(localMsgId: LocalMsgId): MessageMapStateEntity?
+
+    @Query("DELETE FROM MessageMapStateEntity WHERE rowId = :rowId")
+    fun deleteById(rowId: Long)
 }
 
 class LoggingMessageMapDao(val baseDao: MessageMapDao) : MessageMapDao {
@@ -45,5 +48,10 @@ class LoggingMessageMapDao(val baseDao: MessageMapDao) : MessageMapDao {
             Log.d(TAG, "Retrieved message map ${map.localMsgId}->${map.globalMsgId} using local msg Id")
 
         return map
+    }
+
+    override fun deleteById(rowId: Long) {
+        baseDao.deleteById(rowId)
+        Log.d(TAG, "Deleted message map with id $rowId")
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/databases/MessageMapState.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/databases/MessageMapState.kt
@@ -8,4 +8,5 @@ sealed class MessageMapState {
     data class Unknown(val dummy: Unit = Unit) : MessageMapState()
     data class Partial(val smsSendStatus: EventDto.SmsSendStatus, val rowId: Long? = null) : MessageMapState()
     data class Available(val globalMsgId: GlobalMsgId, val localMsgId: LocalMsgId, val rowId: Long? = null) : MessageMapState()
+    data class Deleted(val rowId: Long?) : MessageMapState()
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/databases/MessageMapStateEntity.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/databases/MessageMapStateEntity.kt
@@ -8,7 +8,7 @@ import org.cpardi.messagemirror.models.StateType
 
 @Entity
 data class MessageMapStateEntity(
-    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @PrimaryKey(autoGenerate = true) val rowId: Long = 0,
     val stateType: StateType,
     val globalMsgId: GlobalMsgId? = null,
     val localMsgId: LocalMsgId? = null,

--- a/app/src/main/kotlin/org/cpardi/messagemirror/databases/MirrorDatabase.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/databases/MirrorDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import org.cpardi.messagemirror.helpers.Converters
 
-@Database(entities = [MessageMapStateEntity::class], version = 4)
+@Database(entities = [MessageMapStateEntity::class], version = 8)
 @TypeConverters(Converters::class)
 abstract class MirrorDatabase : RoomDatabase() {
     abstract fun MessageMapDao(): MessageMapDao

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Ids.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Ids.kt
@@ -6,6 +6,7 @@ import org.cpardi.messagemirror.models.GlobalMsgId
 import org.cpardi.messagemirror.models.LocalMsgId
 
 fun Int.toLocalMsgId(): LocalMsgId = LocalMsgId("$this")
+fun LocalMsgId.toLong(): Long = this.value.toLong()
 fun LocalMsgId.toUri(): Uri = Uri.parse("${Sms.CONTENT_URI}/${this.value}")
 fun Uri.toLocalMsgId(): LocalMsgId = this.lastPathSegment?.toIntOrNull()?.toLocalMsgId()!!
 fun LocalMsgId.toGlobalMsgId(deviceId: String): GlobalMsgId = GlobalMsgId("$deviceId;${this.value}")

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/MessageMapState.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/MessageMapState.kt
@@ -25,6 +25,12 @@ fun MessageMapState.toEntity(globalMsgId: GlobalMsgId): MessageMapStateEntity = 
         globalMsgId = globalMsgId,
         localMsgId = localMsgId
     )
+
+    is MessageMapState.Deleted -> MessageMapStateEntity(
+        stateType = StateType.Deleted,
+        globalMsgId = globalMsgId,
+        rowId = rowId ?: error("rowId field must always be set in the Deleted state")
+    )
 }
 
 fun MessageMapState.toEntity(localMsgId: LocalMsgId): MessageMapStateEntity = when (this) {
@@ -44,6 +50,12 @@ fun MessageMapState.toEntity(localMsgId: LocalMsgId): MessageMapStateEntity = wh
         localMsgId = localMsgId,
         globalMsgId = this.globalMsgId,
     )
+
+    is MessageMapState.Deleted -> MessageMapStateEntity(
+        stateType = StateType.Deleted,
+        localMsgId = localMsgId,
+        rowId = rowId ?: error("rowId field must always be set in the Deleted state")
+    )
 }
 
 fun MessageMapStateEntity?.toState(): MessageMapState =
@@ -59,10 +71,14 @@ fun MessageMapStateEntity?.toState(): MessageMapState =
 
             StateType.Available -> {
                 if (localMsgId != null) {
-                    MessageMapState.Available(globalMsgId!!, localMsgId)
+                    MessageMapState.Available(globalMsgId!!, localMsgId, rowId)
                 } else {
                     error("Available state missing localMsgId")
                 }
+            }
+
+            StateType.Deleted -> {
+                MessageMapState.Deleted(rowId)
             }
 
             else -> throw IllegalArgumentException("Unknown stateType: $stateType")

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
@@ -62,6 +62,19 @@ sealed class EventDto {
         val smsSendStatus: SmsSendStatus
     ) : EventDto()
 
+    data class DeleteSms(
+        val localMsgId: LocalMsgId,
+        val metadata: EventMetadataDto,
+        val isMms: Boolean
+    ) : EventDto()
+
+    @Serializable
+    data class DeleteSmsMirrored(
+        val globalMsgId: GlobalMsgId,
+        val metadata: EventMetadataDto,
+        val isMms: Boolean
+    ) : EventDto()
+
 
     companion object {
         /** Enables polymorphic serialisation for this class */
@@ -70,10 +83,9 @@ sealed class EventDto {
                 serializersModule = SerializersModule {
                     polymorphic(EventDto::class) {
                         subclass(SmsReceiveMirrored::class)
-                        subclass(SmsSend::class)
                         subclass(SmsSendMirrored::class)
-                        subclass(SmsSendStatus::class)
                         subclass(SmsSendStatusMirrored::class)
+                        subclass(DeleteSmsMirrored::class)
                     }
                 }
                 classDiscriminator = "type"

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/StateType.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/StateType.kt
@@ -3,5 +3,6 @@ package org.cpardi.messagemirror.models
 enum class StateType {
     Unknown,
     Partial,
-    Available
+    Available,
+    Deleted
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/MessageMapStateMachine.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/MessageMapStateMachine.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import org.cpardi.messagemirror.databases.LoggingMessageMapDao
 import org.cpardi.messagemirror.databases.MessageMapDao
 import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.databases.MessageMapStateEntity
 import org.cpardi.messagemirror.databases.MirrorDatabase
 import org.cpardi.messagemirror.extensions.toEntity
 import org.cpardi.messagemirror.extensions.toState
@@ -27,6 +28,10 @@ import org.cpardi.messagemirror.models.Keyed
 import org.cpardi.messagemirror.models.LKeyed
 import org.cpardi.messagemirror.models.LocalMsgId
 import org.cpardi.messagemirror.models.StateType
+import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsInAvailable
+import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsInUnknown
+import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsMirroredInAvailable
+import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsMirroredInUnknown
 
 private val TAG: String = MessageMapStateMachine::class.qualifiedName!!
 
@@ -53,6 +58,12 @@ class MessageMapStateMachine(val context: Context) {
     private val onSmsSendStatusMirroredInUnknown = OnSmsSendStatusMirroredInUnknown(context)
     private val onSmsSendStatusMirroredInAvailable = OnSmsSendStatusMirroredInAvailable(context)
 
+    private val onDeleteSmsInUnknown = OnDeleteSmsInUnknown(context)
+    private val onDeleteSmsInAvailable = OnDeleteSmsInAvailable(context)
+
+    private val onDeleteSmsMirroredInUnknown = OnDeleteSmsMirroredInUnknown(context)
+    private val onDeleteSmsMirroredInAvailable = OnDeleteSmsMirroredInAvailable(context)
+
     private val onAnyEventPost = OnAnyEventPost(context)
 
     fun process(dto: EventDto) = runBlocking(@OptIn(ExperimentalCoroutinesApi::class)singleThreadDispatcher) {
@@ -67,6 +78,9 @@ class MessageMapStateMachine(val context: Context) {
 
             is EventDto.SmsSendStatus -> onSmsSendStatus(dto)
             is EventDto.SmsSendStatusMirrored -> onSmsSendStatusMirrored(dto)
+
+            is EventDto.DeleteSms -> onDeleteSms(dto)
+            is EventDto.DeleteSmsMirrored -> onDeleteSmsMirrored(dto)
         }
 
         onAnyEventPost.handle(dto)
@@ -100,6 +114,7 @@ class MessageMapStateMachine(val context: Context) {
             is MessageMapState.Unknown -> updateState(onSmsSendStatusInUnknown.handle(status))
             is MessageMapState.Partial -> state.disallowed(status)
             is MessageMapState.Available -> updateState(onSmsSendStatusInAvailable.handle(Keyed(state.globalMsgId, state), status))
+            is MessageMapState.Deleted -> state.disallowed(status)
         }
     }
 
@@ -109,7 +124,28 @@ class MessageMapStateMachine(val context: Context) {
             is MessageMapState.Unknown -> onSmsSendStatusMirroredInUnknown.handle(status)
             is MessageMapState.Partial -> state.disallowed(status)
             is MessageMapState.Available -> onSmsSendStatusMirroredInAvailable.handle(Keyed(keyedState.globalMsgId, state), status)
+            is MessageMapState.Deleted -> state.disallowed(status)
         }.let { updateState(it) }
+    }
+
+    private fun onDeleteSms(delete: EventDto.DeleteSms) {
+        val keyedState = LKeyed(delete.localMsgId, getCurrentState(delete.localMsgId))
+        when (val state = keyedState.item) {
+            is MessageMapState.Unknown -> onDeleteSmsInUnknown.handle(delete)
+            is MessageMapState.Partial -> state.disallowed(delete)
+            is MessageMapState.Available -> updateState(onDeleteSmsInAvailable.handle(state, delete))
+            is MessageMapState.Deleted -> state.disallowed(delete)
+        }
+    }
+
+    private fun onDeleteSmsMirrored(delete: EventDto.DeleteSmsMirrored) {
+        val keyedState = Keyed(delete.globalMsgId, getCurrentState(delete.globalMsgId))
+        when (val state = keyedState.item) {
+            is MessageMapState.Unknown -> onDeleteSmsMirroredInUnknown.handle(delete)
+            is MessageMapState.Partial -> state.disallowed(delete)
+            is MessageMapState.Available -> updateState(onDeleteSmsMirroredInAvailable.handle(state, delete))
+            is MessageMapState.Deleted -> state.disallowed(delete)
+        }
     }
 
     private fun getCurrentState(localMsgId: LocalMsgId): MessageMapState {
@@ -126,25 +162,25 @@ class MessageMapStateMachine(val context: Context) {
     }
 
     private fun updateState(state: Keyed<MessageMapState>?) {
-        if (state == null)
-            return
-
+        if (state == null) return
         val entity = state.item.toEntity(state.globalMsgId)
-        if (entity.stateType != StateType.Unknown)
-            dao.upsert(entity)
-
-        Log.d(TAG, "State machine ${state.globalMsgId}, transition to ${state.item::class.simpleName}")
+        updateEntityState(entity, state.globalMsgId.toString(), state.item::class.simpleName)
     }
 
     private fun updateState(keyedState: LKeyed<MessageMapState>?) {
-        if (keyedState == null)
-            return
-
+        if (keyedState == null) return
         val entity = keyedState.item.toEntity(keyedState.localMsgId)
-        if (entity.stateType != StateType.Unknown)
-            dao.upsert(entity)
+        updateEntityState(entity, keyedState.localMsgId.toString(), keyedState.item::class.simpleName)
+    }
 
-        Log.d(TAG, "State machine ${keyedState.localMsgId}, transition to ${keyedState.item::class.simpleName}")
+    private fun updateEntityState(entity: MessageMapStateEntity, id: String, stateName: String?) {
+        when (entity.stateType) {
+            StateType.Deleted -> dao.deleteById(entity.rowId)
+            StateType.Unknown -> {} // Do nothing for Unknown state
+            else -> dao.upsert(entity)
+        }
+
+        Log.d(TAG, "State machine $id, transition to $stateName")
     }
 
     private fun updateStates(states: List<Keyed<MessageMapState>>?) {
@@ -159,8 +195,8 @@ class MessageMapStateMachine(val context: Context) {
         return null
     }
 
-    private fun MessageMapState.Available.disallowed(dto: EventDto): Keyed<MessageMapState.Available>? {
-        Log.w(TAG, "State machine ${this.globalMsgId}, event '${dto::class.simpleName}' is not allowed when in state '${this::class.simpleName}'")
+    private fun MessageMapState.Deleted.disallowed(dto: EventDto): Keyed<MessageMapState.Deleted>? {
+        Log.w(TAG, "State machine ${this.rowId}, event '${dto::class.simpleName}' is not allowed when in state '${this::class.simpleName}'")
         return null
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsInAvailable.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsInAvailable.kt
@@ -1,0 +1,20 @@
+package org.cpardi.messagemirror.stateMachines.handlers
+
+import android.content.Context
+import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.mirrorEvent
+import org.cpardi.messagemirror.extensions.toLong
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.LKeyed
+import org.fossify.messages.extensions.deleteMessageOnDevice
+
+class OnDeleteSmsInAvailable(val context: Context) {
+    fun handle(state: MessageMapState.Available, dto: EventDto.DeleteSms): LKeyed<MessageMapState.Deleted>? {
+        context.deleteMessageOnDevice(dto.localMsgId.toLong(), dto.isMms)
+
+        val mirroredDto = EventDto.DeleteSmsMirrored(state.globalMsgId, dto.metadata, dto.isMms)
+        context.mirrorEvent(mirroredDto)
+
+        return LKeyed(dto.localMsgId, MessageMapState.Deleted(state.rowId))
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsInUnknown.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsInUnknown.kt
@@ -1,0 +1,19 @@
+package org.cpardi.messagemirror.stateMachines.handlers
+
+import android.content.Context
+import android.util.Log
+import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.toLong
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.LKeyed
+import org.fossify.messages.extensions.deleteMessageOnDevice
+
+private val TAG = OnDeleteSmsInUnknown::class.qualifiedName!!
+
+class OnDeleteSmsInUnknown(val context: Context) {
+    fun handle(dto: EventDto.DeleteSms): LKeyed<MessageMapState.Unknown>? {
+        context.deleteMessageOnDevice(dto.localMsgId.toLong(), dto.isMms)
+        Log.w(TAG, "SMS ${dto.localMsgId} deletion mirror failed because mapping is unknown")
+        return null
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsMirroredInAvailable.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsMirroredInAvailable.kt
@@ -1,0 +1,24 @@
+package org.cpardi.messagemirror.stateMachines.handlers
+
+import android.content.Context
+import android.util.Log
+import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.mirrorConfig
+import org.cpardi.messagemirror.extensions.toLong
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.Keyed
+import org.fossify.messages.extensions.deleteMessageOnDevice
+
+private val TAG = OnDeleteSmsMirroredInAvailable::class.qualifiedName!!
+
+class OnDeleteSmsMirroredInAvailable(val context: Context) {
+    fun handle(state: MessageMapState.Available, dto: EventDto.DeleteSmsMirrored): Keyed<MessageMapState>? {
+        if (context.mirrorConfig.deviceID == dto.metadata.senderID) {
+            Log.d(TAG, "Ignored ${dto::class.simpleName} as sent from this device(${context.mirrorConfig.deviceID})")
+            return null
+        }
+
+        context.deleteMessageOnDevice(state.localMsgId.toLong(), dto.isMms)
+        return Keyed(dto.globalMsgId, MessageMapState.Deleted(state.rowId))
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsMirroredInUnknown.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsMirroredInUnknown.kt
@@ -1,0 +1,22 @@
+package org.cpardi.messagemirror.stateMachines.handlers
+
+import android.content.Context
+import android.util.Log
+import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.mirrorConfig
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.LKeyed
+
+private val TAG = OnDeleteSmsMirroredInUnknown::class.qualifiedName!!
+
+class OnDeleteSmsMirroredInUnknown(val context: Context) {
+    fun handle(dto: EventDto.DeleteSmsMirrored): LKeyed<MessageMapState.Unknown>? {
+        if (context.mirrorConfig.deviceID == dto.metadata.senderID) {
+            Log.d(TAG, "Ignored ${dto::class.simpleName} as sent from this device(${context.mirrorConfig.deviceID})")
+            return null
+        }
+
+        Log.w(TAG, "SMS ${dto.globalMsgId} local deletion failed because mapping was unknown")
+        return null
+    }
+}

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendMirroredInMultipleStates.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendMirroredInMultipleStates.kt
@@ -58,6 +58,7 @@ class OnSmsSendMirroredInMultipleStates(val context: Context) {
                 }
 
                 is MessageMapState.Available -> error("Event '${sendMirrored::class.simpleName}' not allowed when in state '${state::class.simpleName}'")
+                is MessageMapState.Deleted -> error("Event '${sendMirrored::class.simpleName}' not allowed when in state '${state::class.simpleName}'")
             }
         }
     }

--- a/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
@@ -25,6 +25,11 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
 import com.google.android.mms.pdu_alt.PduHeaders
+import org.cpardi.messagemirror.extensions.messageMapStateMachine
+import org.cpardi.messagemirror.extensions.mirrorConfig
+import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.models.EventMetadataDto
+import org.cpardi.messagemirror.models.LocalMsgId
 import org.fossify.commons.extensions.areDigitsOnly
 import org.fossify.commons.extensions.getBlockedNumbers
 import org.fossify.commons.extensions.getIntValue
@@ -962,6 +967,13 @@ fun Context.updateConversationArchivedStatus(threadId: Long, archived: Boolean) 
 }
 
 fun Context.deleteMessage(id: Long, isMMS: Boolean) {
+    val config = this.mirrorConfig
+    val metadata = EventMetadataDto(config.deviceID)
+    val dto: EventDto = EventDto.DeleteSms(LocalMsgId(id.toString()), metadata, isMMS)
+    messageMapStateMachine.process(dto)
+}
+
+fun Context.deleteMessageOnDevice(id: Long, isMMS: Boolean) {
     val uri = if (isMMS) Mms.CONTENT_URI else Sms.CONTENT_URI
     val selection = "${Sms._ID} = ?"
     val selectionArgs = arrayOf(id.toString())
@@ -1027,7 +1039,7 @@ fun Context.markThreadMessagesUnread(threadId: Long) {
         contentResolver.update(uri, contentValues, selection, selectionArgs)
     }
     conversationsDB.markUnread(threadId)
-} 
+}
 
 @SuppressLint("NewApi")
 fun Context.getThreadId(address: String): Long {


### PR DESCRIPTION
Hook into context.deleteMessage to initiate state machine process and rename original implementation to deleteMessageOnDevice.

- Implement OnDeleteSmsInUnknown and OnDeleteSmsInAvailable handlers for local deletions
- Implement OnDeleteSmsMirroredInUnknown and OnDeleteSmsMirroredInAvailable handlers for mirrored deletions
- Update EventDto to include DeleteSms and DeleteSmsMirrored events
- Add Deleted state to MessageMapState and StateType enum
- Add deleteById method to MessageMapDao and LoggingMessageMapDao