### PR TITLE
Support self-hosted ntfy servers by using full topic URLs

### DIFF
--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
@@ -9,7 +9,6 @@ import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.helpers.MirrorConfig
 import org.cpardi.messagemirror.models.EventDto
-import org.fossify.commons.helpers.ensureBackgroundThread
 import javax.crypto.spec.SecretKeySpec
 
 private const val TAG: String = "org.cpardi.messagemirror.extensions"
@@ -17,7 +16,7 @@ private const val TAG: String = "org.cpardi.messagemirror.extensions"
 val Context.mirrorConfig: MirrorConfig
     get() = MirrorConfig(this)
 
-val Context.messageMapStateMachine : MessageMapStateMachine
+val Context.messageMapStateMachine: MessageMapStateMachine
     get() = MessageMapStateMachine(this)
 
 fun Context.mirrorEvent(dto: EventDto) {
@@ -25,15 +24,16 @@ fun Context.mirrorEvent(dto: EventDto) {
     val keyBytes = Base64.decode(config.encryptionKey, Base64.NO_WRAP)
     val key = SecretKeySpec(keyBytes, CryptoHelper.ALGORITHM)
 
-    ensureBackgroundThread {
-        val message = EventDto.Serializer.encodeToString(dto)
-        val encryptedMessage = CryptoHelper.encrypt(message, key)
+    val message = EventDto.Serializer.encodeToString(dto)
+    val encryptedMessage = CryptoHelper.encrypt(message, key)
 
-        val ntfyIntent = Intent(Constants.ACTION_NTFY_SEND_MESSAGE)
-        ntfyIntent.setPackage(Constants.PACKAGE_NTFY)
-        ntfyIntent.putExtra(Constants.INTENT_NTFY_TOPIC, config.topic)
-        ntfyIntent.putExtra(Constants.INTENT_NTFY_MESSAGE, encryptedMessage)
-        this.sendBroadcast(ntfyIntent)
-        Log.d(TAG, "Broadcast intent of mirroring ${dto.javaClass.simpleName} event")
-    }
+    val ntfyIntent = Intent(Constants.ACTION_NTFY_SEND_MESSAGE)
+    ntfyIntent.setPackage(Constants.PACKAGE_NTFY)
+    val baseUrl = config.topicUrl.baseURI
+    val topic = config.topicUrl.path.removePrefix("/")
+    ntfyIntent.putExtra(Constants.INTENT_NTFY_BASE_URL, baseUrl)
+    ntfyIntent.putExtra(Constants.INTENT_NTFY_TOPIC, topic)
+    ntfyIntent.putExtra(Constants.INTENT_NTFY_MESSAGE, encryptedMessage)
+    this.sendBroadcast(ntfyIntent)
+    Log.d(TAG, "Broadcast intent of mirroring ${dto.javaClass.simpleName} event to baseURL '${baseUrl}' with topic $topic")
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/URI.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/URI.kt
@@ -1,0 +1,6 @@
+package org.cpardi.messagemirror.extensions
+
+import java.net.URI
+
+val URI.baseURI: String
+    get() = "${this.scheme}://${this.authority}"

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/Constants.kt
@@ -8,6 +8,7 @@ object Constants {
     const val PACKAGE_NTFY = "io.heckel.ntfy"
 
     const val INTENT_NTFY_MESSAGE = "message"
+    const val INTENT_NTFY_BASE_URL = "base_url"
     const val INTENT_NTFY_TOPIC = "topic"
 
     const val SHARED_PREFERENCES_NAME = "org.cpardi.messagemirror"

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/MirrorConfig.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/MirrorConfig.kt
@@ -8,6 +8,7 @@ import org.cpardi.messagemirror.helpers.Constants.CONFIG_MODE
 import org.cpardi.messagemirror.helpers.Constants.SHARED_PREFERENCES_NAME
 import org.cpardi.messagemirror.helpers.Constants.CONFIG_TOPIC
 import org.cpardi.messagemirror.models.DeviceMode
+import java.net.URI
 import java.util.UUID
 
 class MirrorConfig(context: Context) {
@@ -28,9 +29,9 @@ class MirrorConfig(context: Context) {
         get() = prefs.getBoolean(CONFIG_ENABLE, false)
         set(it) = editor.putBoolean(CONFIG_ENABLE, it).apply()
 
-    var topic: String
-        get() = prefs.getString(CONFIG_TOPIC, "")!!
-        set(it) = editor.putString(CONFIG_TOPIC, it).apply()
+    var topicUrl: URI
+        get() = URI(prefs.getString(CONFIG_TOPIC, "")!!)
+        set(it) = editor.putString(CONFIG_TOPIC, it.toString()).apply()
 
     var encryptionKey: String
         get() = prefs.getString(CONFIG_ENCRYPTION_KEY, "")!!

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
@@ -12,6 +12,7 @@ import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import android.util.Base64
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
@@ -23,12 +24,16 @@ import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.models.EventDto
+import org.cpardi.messagemirror.stateMachines.handlers.OnSmsSendMirroredInMultipleStates
 import org.fossify.commons.extensions.showErrorToast
 import org.fossify.messages.R
 import org.fossify.messages.activities.MainActivity
+import java.net.URI
 import javax.crypto.BadPaddingException
 import javax.crypto.IllegalBlockSizeException
 import javax.crypto.spec.SecretKeySpec
+
+private val TAG: String = OnSmsSendMirroredInMultipleStates::class.qualifiedName!!
 
 class EventConsumerService : Service() {
 
@@ -51,10 +56,16 @@ class EventConsumerService : Service() {
                 try {
                     val config = context.mirrorConfig
                     val stateMachine = context.messageMapStateMachine
-                    val topic = intent.getStringExtra(Constants.INTENT_NTFY_TOPIC)
 
-                    if (!config.enabled || topic != config.topic)
+                    val topicUrl = config.topicUrl
+                    val baseUrl = intent.getStringExtra(Constants.INTENT_NTFY_BASE_URL)
+                    val topic = intent.getStringExtra(Constants.INTENT_NTFY_TOPIC)
+                    val subscribedTopicUrl = URI("$baseUrl/$topic")
+
+                    if (!config.enabled || topicUrl != subscribedTopicUrl) {
+                        Log.d(TAG, "Subscribed to topic URL ${subscribedTopicUrl}, but received $topicUrl")
                         return@launch
+                    }
 
                     val keyBytes = Base64.decode(config.encryptionKey, Base64.NO_WRAP)
                     val key = SecretKeySpec(keyBytes, CryptoHelper.ALGORITHM)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/MessageMapStateMachine.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/MessageMapStateMachine.kt
@@ -2,8 +2,8 @@ package org.cpardi.messagemirror.stateMachines
 
 import android.content.Context
 import android.util.Log
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.cpardi.messagemirror.databases.LoggingMessageMapDao
 import org.cpardi.messagemirror.databases.MessageMapDao
@@ -32,12 +32,14 @@ import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsInAvailable
 import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsInUnknown
 import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsMirroredInAvailable
 import org.cpardi.messagemirror.stateMachines.handlers.OnDeleteSmsMirroredInUnknown
+import java.util.concurrent.Executors
 
 private val TAG: String = MessageMapStateMachine::class.qualifiedName!!
 
 class MessageMapStateMachine(val context: Context) {
     companion object {
-        private val singleThreadDispatcher = @OptIn(ExperimentalCoroutinesApi::class)newSingleThreadContext("MessageMapStateMachineThread")
+        private val singleThreadExecutor = Executors.newSingleThreadExecutor()
+        private val singleThreadDispatcher: ExecutorCoroutineDispatcher = singleThreadExecutor.asCoroutineDispatcher()
         private var DaoInstance: MessageMapDao? = null
     }
 
@@ -66,7 +68,7 @@ class MessageMapStateMachine(val context: Context) {
 
     private val onAnyEventPost = OnAnyEventPost(context)
 
-    fun process(dto: EventDto) = runBlocking(@OptIn(ExperimentalCoroutinesApi::class)singleThreadDispatcher) {
+    fun process(dto: EventDto) = runBlocking(singleThreadDispatcher) {
         Log.d(TAG, "State machine started processing ${dto::class.simpleName} event")
         when (dto) {
             is EventDto.SmsReceive -> onSmsReceive(dto)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendMirroredInMultipleStates.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendMirroredInMultipleStates.kt
@@ -28,10 +28,11 @@ class OnSmsSendMirroredInMultipleStates(val context: Context) {
             localMsgIds.add(uri.toLocalMsgId())
         }
 
+
         context.sendMessageOnDeviceCompat(
             sendMirrored.smsSend.text,
             sendMirrored.smsSend.addresses,
-            sendMirrored.smsSend.subId,
+            null, // Use the default subscription (SIM card) for the time being
             sendMirrored.smsSend.attachments.map { attachmentDto -> attachmentDto.fromDto() },
             handleCreatedUri,
             sendMirrored.smsSend.messageId,

--- a/app/src/main/kotlin/org/cpardi/messagemirror/views/MirrorSettingsView.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/views/MirrorSettingsView.kt
@@ -33,6 +33,7 @@ import org.fossify.commons.extensions.updateTextColors
 import org.fossify.commons.models.RadioItem
 import org.fossify.messages.databinding.ViewMirrorSettingsBinding
 import org.fossify.messages.extensions.toArrayList
+import java.net.URI
 import java.security.SecureRandom
 
 class MirrorSettingsView @JvmOverloads constructor(
@@ -112,13 +113,13 @@ class MirrorSettingsView @JvmOverloads constructor(
     }
 
     private fun setupTopic() = binding.apply {
-        mirrorSettingsTopicEdittext.setText(config.topic)
+        mirrorSettingsTopicEdittext.setText(config.topicUrl.toString())
 
         mirrorSettingsTopicEdittext.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { // This is intentionally empty
             }
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                config.topic = s?.toString() ?: ""
+                config.topicUrl = URI(s?.toString() ?: "")
             }
             override fun afterTextChanged(s: Editable?) { // This is intentionally empty
             }
@@ -176,7 +177,7 @@ class MirrorSettingsView @JvmOverloads constructor(
 
     private fun setupShare() = binding.apply {
         mirrorSettingsShareHolder.setOnClickListener {
-            ShareMirrorSettingsDialog(context, "${config.topic};${config.encryptionKey}")
+            ShareMirrorSettingsDialog(context, "${config.topicUrl};${config.encryptionKey}")
         }
     }
 

--- a/app/src/main/res/layout/view_mirror_settings.xml
+++ b/app/src/main/res/layout/view_mirror_settings.xml
@@ -86,7 +86,7 @@
                     style="@style/SettingsTextLabelStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/topic" />
+                    android:text="@string/topic_url" />
 
                 <org.fossify.commons.views.MyEditText
                     android:id="@+id/mirror_settings_topic_edittext"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,7 +144,7 @@
     <string name="enable_mirror">Enable Mirror</string>
     <string name="ntfy_warning">Warning: ntfy.sh app is not installed. Please install it from the Play Store.</string>
     <string name="device_mode">Device Mode</string>
-    <string name="topic">Topic</string>
+    <string name="topic_url">Topic URL</string>
     <string name="example_topic">JCCtIRlCnhkr3Tky</string>
     <string name="generate_random_topic">Generate random topic</string>
     <string name="copy_topic_to_clipboard">Copy topic to clipboard</string>


### PR DESCRIPTION
- Change MirrorConfig to store topic as a URI instead of a plain string and update MirrorSettingsView to display and edit the full topic URL
- Modify Context.mirrorEvent to send base URL and topic path separately in the broadcast intent
- Update EventConsumerService to compare full topic URLs for filtering events
- Use default subscription (null) when sending SMS in OnSmsSendMirroredInMultipleStates handler
- Replace experimental newSingleThreadContext with ExecutorCoroutineDispatcher in MessageMapStateMachine