### PR TITLE
Use Base64 string encoding and compression to optimise event data size

### DIFF
--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Serialization.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Serialization.kt
@@ -2,11 +2,13 @@ package org.cpardi.messagemirror.extensions
 
 import android.content.Intent
 import android.os.Parcel
+import android.util.Base64
 
-fun ByteArray.toIntent(): Intent {
+fun String.toIntent(): Intent {
     val parcel = Parcel.obtain()
     try {
-        parcel.unmarshall(this, 0, this.size)
+        val bytes = Base64.decode(this, Base64.NO_WRAP)
+        parcel.unmarshall(bytes, 0, bytes.size)
         parcel.setDataPosition(0)
         return Intent.CREATOR.createFromParcel(parcel)
     } finally {
@@ -14,12 +16,13 @@ fun ByteArray.toIntent(): Intent {
     }
 }
 
-fun Intent.toByteArray(): ByteArray {
+fun Intent.serialise(): String {
     val parcel = Parcel.obtain()
     try {
         this.writeToParcel(parcel, 0)
         val parcelBytes = parcel.marshall()
-        return parcelBytes
+        val base64String = Base64.encodeToString(parcelBytes, Base64.NO_WRAP)
+        return base64String
 
     } finally {
         parcel.recycle()

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/CryptoHelper.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/CryptoHelper.kt
@@ -1,8 +1,11 @@
 package org.cpardi.messagemirror.helpers
 
 import android.util.Base64
+import java.io.ByteArrayOutputStream
 import java.nio.charset.Charset
 import java.security.SecureRandom
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -22,25 +25,33 @@ object CryptoHelper {
     }
 
     fun encrypt(plainText: String, key: SecretKeySpec): String {
+        val compressed =
+            ByteArrayOutputStream().use {
+                GZIPOutputStream(it).use { gzip -> gzip.write(plainText.toByteArray(CHARSET)) }
+                it.toByteArray()
+            }
+
         val cipher = Cipher.getInstance(TRANSFORMATION)
         val iv = ByteArray(size = 16)
         secureRandom.nextBytes(iv)
         val ivSpec = IvParameterSpec(iv)
         cipher.init(Cipher.ENCRYPT_MODE, key, ivSpec)
-        val encrypted = cipher.doFinal(plainText.toByteArray(CHARSET))
-        // Prepend IV to encrypted bytes
-        val combined = iv + encrypted
+        val encrypted = cipher.doFinal(compressed)
+        val combined = iv + encrypted // Prepend IV to encrypted bytes
+
         return Base64.encodeToString(combined, Base64.NO_WRAP)
     }
 
     fun decrypt(encryptedBase64: String, key: SecretKeySpec): String {
         val combined = Base64.decode(encryptedBase64, Base64.NO_WRAP)
         val iv = combined.copyOfRange(fromIndex = 0, toIndex = 16)
-        val encrypted = combined.copyOfRange(fromIndex =  16, toIndex = combined.size)
+        val encrypted = combined.copyOfRange(fromIndex = 16, toIndex = combined.size)
         val cipher = Cipher.getInstance(TRANSFORMATION)
         val ivSpec = IvParameterSpec(iv)
         cipher.init(Cipher.DECRYPT_MODE, key, ivSpec)
         val decrypted = cipher.doFinal(encrypted)
-        return String(decrypted, CHARSET)
+        val uncompressed = GZIPInputStream(decrypted.inputStream()).use { gzip -> gzip.readBytes() }
+
+        return String(uncompressed, CHARSET)
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/EventDto.kt
@@ -28,7 +28,7 @@ sealed class EventDto {
     data class SmsReceiveMirrored(
         val metadata: EventMetadataDto,
         val globalMsgId: GlobalMsgId,
-        val intentBytes: List<Byte>
+        val intentData: String
     ) : EventDto()
 
     /** Represents when an SMS message is sent */
@@ -53,7 +53,7 @@ sealed class EventDto {
     data class SmsSendStatus(
         val localMsgId: LocalMsgId,
         val metadata: EventMetadataDto,
-        val intentParcel: List<Byte>
+        val intentData: String
     ) : EventDto()
 
     @Serializable
@@ -88,6 +88,8 @@ sealed class EventDto {
                         subclass(DeleteSmsMirrored::class)
                     }
                 }
+                explicitNulls = false
+                prettyPrint = false
                 classDiscriminator = "type"
                 ignoreUnknownKeys = true
             }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSendStatusReceiver.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/receivers/ForwardingSendStatusReceiver.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import org.cpardi.messagemirror.extensions.messageMapStateMachine
 import org.cpardi.messagemirror.extensions.mirrorConfig
-import org.cpardi.messagemirror.extensions.toByteArray
+import org.cpardi.messagemirror.extensions.serialise
 import org.cpardi.messagemirror.extensions.toLocalMsgId
 import org.cpardi.messagemirror.models.DeviceMode
 import org.cpardi.messagemirror.models.EventDto
@@ -17,10 +17,9 @@ abstract class ForwardingSendStatusReceiver : SendStatusReceiver() {
         val config = context.mirrorConfig
 
         if (config.mode == DeviceMode.SmsHost) {
-            val intentByteArray = intent.toByteArray().toList()
             val metadata = EventMetadataDto(config.deviceID)
             val localMsgId = intent.data?.toLocalMsgId()!!
-            val dto = EventDto.SmsSendStatus(localMsgId, metadata, intentByteArray)
+            val dto = EventDto.SmsSendStatus(localMsgId, metadata, intent.serialise())
             context.messageMapStateMachine.process(dto)
         }
 

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsPartReceiveInUnknown.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsPartReceiveInUnknown.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import org.cpardi.messagemirror.databases.MessageMapState
 import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.extensions.mirrorEvent
-import org.cpardi.messagemirror.extensions.toByteArray
+import org.cpardi.messagemirror.extensions.serialise
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.models.Keyed
 
 class OnSmsPartReceiveInUnknown(val context: Context) {
     fun handle(dto: EventDto.SmsPartReceive): Keyed<MessageMapState> {
         if (context.mirrorConfig.deviceID == dto.metadata.senderID) {
-            context.mirrorEvent(EventDto.SmsReceiveMirrored(dto.metadata, dto.globalMsgId, dto.intent.toByteArray().toList()))
+            context.mirrorEvent(EventDto.SmsReceiveMirrored(dto.metadata, dto.globalMsgId, dto.intent.serialise()))
         }
 
         return Keyed(dto.globalMsgId, MessageMapState.Available(dto.globalMsgId, dto.localMsgId))

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsReceiveMirroredInUnknown.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsReceiveMirroredInUnknown.kt
@@ -20,7 +20,7 @@ class OnSmsReceiveMirroredInUnknown(val context: Context) {
             return null
         }
 
-        val intent = dto.intentBytes.toByteArray().toIntent()
+        val intent = dto.intentData.toIntent()
         val receiver = SmsReceiver { localId ->
             val localMsgId = LocalMsgId(localId.toString())
             val partDto = EventDto.SmsPartReceive(dto.globalMsgId, localMsgId, dto.metadata, intent)

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendStatusMirroredInAvailable.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendStatusMirroredInAvailable.kt
@@ -18,7 +18,7 @@ class OnSmsSendStatusMirroredInAvailable(val context: Context) {
             return null
         }
 
-        val intent = dto.smsSendStatus.intentParcel.toByteArray().toIntent()
+        val intent = dto.smsSendStatus.intentData.toIntent()
         intent.data = state.item.localMsgId.toUri()
         context.sendBroadcast(intent)
         Log.d(TAG, "Broadcast intent of ${intent.action} with URI ${intent.data} from event received from ${dto.smsSendStatus.metadata.senderID}")


### PR DESCRIPTION
- Update EventDto to use String for intent data
- Compress output before encrypting message
- Disable explicitNulls and prettyPrint in JSON config for compact JSON output