### PR TITLE
Update the mirror settings UI 

### DIFF
--- a/app/src/main/kotlin/org/cpardi/messagemirror/dialogs/ShareMirrorSettingsDialog.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/dialogs/ShareMirrorSettingsDialog.kt
@@ -2,28 +2,44 @@ package org.cpardi.messagemirror.dialogs
 
 import android.app.AlertDialog
 import android.content.Context
+import android.view.LayoutInflater
 import android.widget.ImageView
+import android.widget.TextView
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
 import com.google.zxing.common.BitMatrix
 import com.journeyapps.barcodescanner.BarcodeEncoder
+import org.fossify.commons.extensions.getProperPrimaryColor
+import org.fossify.commons.extensions.getProperTextColor
+import org.fossify.messages.R
 
-private const val WIDTH: Int = 400
-private const val HEIGHT = 400
+private const val WIDTH: Int = 600
+private const val HEIGHT = 600
 
 class ShareMirrorSettingsDialog(activity: Context, text: String) {
     init {
+        val inflater = LayoutInflater.from(activity)
+        val view = inflater.inflate(R.layout.dialog_share_mirror_settings, null)
+
         val multiFormatWriter = MultiFormatWriter()
         val bitMatrix: BitMatrix = multiFormatWriter.encode(text, BarcodeFormat.QR_CODE, WIDTH, HEIGHT)
         val barcodeEncoder = BarcodeEncoder()
         val qrBitmap = barcodeEncoder.createBitmap(bitMatrix)
 
-        val imageView = ImageView(activity)
-        imageView.setImageBitmap(qrBitmap)
+        val qrImageView = view.findViewById<ImageView>(R.id.share_mirror_settings_qr_code)
+        qrImageView.setImageBitmap(qrBitmap)
+
+        val titleView = view.findViewById<TextView>(R.id.share_mirror_settings_title)
+        val messageView = view.findViewById<TextView>(R.id.share_mirror_settings_message)
+
+        val primaryColor = activity.getProperPrimaryColor()
+        val textColor = activity.getProperTextColor()
+
+        titleView.setTextColor(primaryColor)
+        messageView.setTextColor(textColor)
+
         AlertDialog.Builder(activity)
-            .setTitle("Share Mirror Settings")
-            .setMessage("""To sync settings, choose "Scan Settings" on your other device and scan this QR code.""")
-            .setView(imageView)
+            .setView(view)
             .setPositiveButton("Close", null)
             .show()
     }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/Context.kt
@@ -2,14 +2,12 @@ package org.cpardi.messagemirror.extensions
 
 import android.content.Context
 import android.content.Intent
-import android.util.Base64
 import android.util.Log
 import org.cpardi.messagemirror.stateMachines.MessageMapStateMachine
 import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.helpers.MirrorConfig
 import org.cpardi.messagemirror.models.EventDto
-import javax.crypto.spec.SecretKeySpec
 
 private const val TAG: String = "org.cpardi.messagemirror.extensions"
 
@@ -21,19 +19,17 @@ val Context.messageMapStateMachine: MessageMapStateMachine
 
 fun Context.mirrorEvent(dto: EventDto) {
     val config = this.mirrorConfig
-    val keyBytes = Base64.decode(config.encryptionKey, Base64.NO_WRAP)
-    val key = SecretKeySpec(keyBytes, CryptoHelper.ALGORITHM)
 
     val message = EventDto.Serializer.encodeToString(dto)
-    val encryptedMessage = CryptoHelper.encrypt(message, key)
+    val encryptedMessage = CryptoHelper.encrypt(message, config.encryptionKey)
 
     val ntfyIntent = Intent(Constants.ACTION_NTFY_SEND_MESSAGE)
     ntfyIntent.setPackage(Constants.PACKAGE_NTFY)
-    val baseUrl = config.topicUrl.baseURI
-    val topic = config.topicUrl.path.removePrefix("/")
+    val baseUrl = config.baseUrl.toString()
+    val topic = config.topic
     ntfyIntent.putExtra(Constants.INTENT_NTFY_BASE_URL, baseUrl)
     ntfyIntent.putExtra(Constants.INTENT_NTFY_TOPIC, topic)
     ntfyIntent.putExtra(Constants.INTENT_NTFY_MESSAGE, encryptedMessage)
     this.sendBroadcast(ntfyIntent)
-    Log.d(TAG, "Broadcast intent of mirroring ${dto.javaClass.simpleName} event to baseURL '${baseUrl}' with topic $topic")
+    Log.d(TAG, "Broadcast intent of mirroring ${dto.javaClass.simpleName} event to baseURL '$baseUrl' with topic $topic")
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/MirrorConfig.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/MirrorConfig.kt
@@ -1,0 +1,7 @@
+package org.cpardi.messagemirror.extensions
+
+import org.cpardi.messagemirror.helpers.MirrorConfig
+import org.cpardi.messagemirror.models.DeviceMode
+
+val MirrorConfig.isEnabled: Boolean
+    get() = this.mode != DeviceMode.None

--- a/app/src/main/kotlin/org/cpardi/messagemirror/extensions/URI.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/extensions/URI.kt
@@ -1,6 +1,0 @@
-package org.cpardi.messagemirror.extensions
-
-import java.net.URI
-
-val URI.baseURI: String
-    get() = "${this.scheme}://${this.authority}"

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/Constants.kt
@@ -15,7 +15,9 @@ object Constants {
 
     const val CONFIG_MODE = "mode"
     const val CONFIG_DEVICE_ID = "device_id"
-    const val CONFIG_ENABLE = "mirror_enabled"
     const val CONFIG_TOPIC = "topic_name"
+    const val CONFIG_BASE_URL = "base_url"
     const val CONFIG_ENCRYPTION_KEY = "encryption_key"
+
+    const val URL_NTFY_DEFAULT = "https://ntfy.sh"
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/CryptoHelper.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/CryptoHelper.kt
@@ -24,7 +24,21 @@ object CryptoHelper {
         return keyGenerator.generateKey()
     }
 
-    fun encrypt(plainText: String, key: SecretKeySpec): String {
+    fun isValidEncryptionKey(keyString: String?): Boolean {
+        if (keyString.isNullOrEmpty()) return false
+
+        return try {
+            encrypt("test", keyString)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    fun encrypt(plainText: String, keyString: String): String {
+        val keyBytes = Base64.decode(keyString, Base64.NO_WRAP)
+        val key = SecretKeySpec(keyBytes, ALGORITHM)
+
         val compressed =
             ByteArrayOutputStream().use {
                 GZIPOutputStream(it).use { gzip -> gzip.write(plainText.toByteArray(CHARSET)) }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/helpers/MirrorConfig.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/helpers/MirrorConfig.kt
@@ -1,12 +1,13 @@
 package org.cpardi.messagemirror.helpers
 
 import android.content.Context
+import org.cpardi.messagemirror.helpers.Constants.CONFIG_BASE_URL
 import org.cpardi.messagemirror.helpers.Constants.CONFIG_DEVICE_ID
-import org.cpardi.messagemirror.helpers.Constants.CONFIG_ENABLE
 import org.cpardi.messagemirror.helpers.Constants.CONFIG_ENCRYPTION_KEY
 import org.cpardi.messagemirror.helpers.Constants.CONFIG_MODE
-import org.cpardi.messagemirror.helpers.Constants.SHARED_PREFERENCES_NAME
 import org.cpardi.messagemirror.helpers.Constants.CONFIG_TOPIC
+import org.cpardi.messagemirror.helpers.Constants.SHARED_PREFERENCES_NAME
+import org.cpardi.messagemirror.helpers.Constants.URL_NTFY_DEFAULT
 import org.cpardi.messagemirror.models.DeviceMode
 import java.net.URI
 import java.util.UUID
@@ -25,19 +26,22 @@ class MirrorConfig(context: Context) {
             return prefs.getString(CONFIG_DEVICE_ID, UUID.randomUUID().toString())!!
         }
 
-    var enabled: Boolean
-        get() = prefs.getBoolean(CONFIG_ENABLE, false)
-        set(it) = editor.putBoolean(CONFIG_ENABLE, it).apply()
+    var mode: DeviceMode
+        get() = DeviceMode.fromInt(prefs.getInt(CONFIG_MODE, 0))
+        set(it) = editor.putInt(CONFIG_MODE, it.value).apply()
 
-    var topicUrl: URI
-        get() = URI(prefs.getString(CONFIG_TOPIC, "")!!)
-        set(it) = editor.putString(CONFIG_TOPIC, it.toString()).apply()
+    var topic: String
+        get() = prefs.getString(CONFIG_TOPIC, "")!!
+        set(it) = editor.putString(CONFIG_TOPIC, it).apply()
+
+    var baseUrl: URI?
+        get() {
+            val baseUrl = prefs.getString(CONFIG_BASE_URL, "")
+            return if (baseUrl.isNullOrBlank()) URI(URL_NTFY_DEFAULT) else URI(baseUrl)
+        }
+        set(it) = editor.putString(CONFIG_BASE_URL, it.toString()).apply()
 
     var encryptionKey: String
         get() = prefs.getString(CONFIG_ENCRYPTION_KEY, "")!!
         set(it) = editor.putString(CONFIG_ENCRYPTION_KEY, it).apply()
-
-    var mode: DeviceMode
-        get() = DeviceMode.fromInt(prefs.getInt(CONFIG_MODE, 1))
-        set(it) = editor.putInt(CONFIG_MODE, it.value).apply()
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/models/DeviceMode.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/models/DeviceMode.kt
@@ -1,12 +1,17 @@
 package org.cpardi.messagemirror.models
 
+import android.content.Context
+import org.fossify.messages.R
+
 enum class DeviceMode(val value: Int) {
+    None(0),
     SmsHost(1),
     Mirror(2);
 
-    fun description(): String = when (this) {
-        SmsHost -> "SMS Host"
-        Mirror -> "Mirror"
+    fun description(context: Context): String = when (this) {
+        None -> context.getString(R.string.device_mode_none)
+        SmsHost -> context.getString(R.string.device_mode_sms_host)
+        Mirror -> context.getString(R.string.device_mode_mirror)
     }
 
     companion object {

--- a/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/services/EventConsumerService.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.os.IBinder
 import android.util.Base64
 import android.util.Log
+import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
@@ -23,6 +24,7 @@ import org.cpardi.messagemirror.extensions.messageMapStateMachine
 import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.helpers.Constants
 import org.cpardi.messagemirror.helpers.CryptoHelper
+import org.cpardi.messagemirror.models.DeviceMode
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.stateMachines.handlers.OnSmsSendMirroredInMultipleStates
 import org.fossify.commons.extensions.showErrorToast
@@ -57,13 +59,12 @@ class EventConsumerService : Service() {
                     val config = context.mirrorConfig
                     val stateMachine = context.messageMapStateMachine
 
-                    val topicUrl = config.topicUrl
-                    val baseUrl = intent.getStringExtra(Constants.INTENT_NTFY_BASE_URL)
+                    val baseUrl = URI(intent.getStringExtra(Constants.INTENT_NTFY_BASE_URL))
                     val topic = intent.getStringExtra(Constants.INTENT_NTFY_TOPIC)
-                    val subscribedTopicUrl = URI("$baseUrl/$topic")
 
-                    if (!config.enabled || topicUrl != subscribedTopicUrl) {
-                        Log.d(TAG, "Subscribed to topic URL ${subscribedTopicUrl}, but received $topicUrl")
+                    if (config.mode == DeviceMode.None) return@launch
+                    if (config.baseUrl != baseUrl || config.topic != topic) {
+                        Log.d(TAG, "Subscribed to topic URL ${config.baseUrl}/${config.topic} , but received $baseUrl/$topic")
                         return@launch
                     }
 
@@ -80,7 +81,7 @@ class EventConsumerService : Service() {
                             is IllegalArgumentException,
                             is IllegalBlockSizeException,
                             is BadPaddingException -> {
-                                context.showErrorToast(e)
+                                context.showErrorToast("A mirrored event could not be decrypted. Exception $e ", Toast.LENGTH_LONG)
                                 return@launch
                             }
 
@@ -131,7 +132,7 @@ class EventConsumerService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        return START_STICKY;
+        return START_STICKY
     }
 
     override fun onDestroy() {

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsInAvailable.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnDeleteSmsInAvailable.kt
@@ -2,6 +2,8 @@ package org.cpardi.messagemirror.stateMachines.handlers
 
 import android.content.Context
 import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.isEnabled
+import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.extensions.mirrorEvent
 import org.cpardi.messagemirror.extensions.toLong
 import org.cpardi.messagemirror.models.EventDto
@@ -12,8 +14,10 @@ class OnDeleteSmsInAvailable(val context: Context) {
     fun handle(state: MessageMapState.Available, dto: EventDto.DeleteSms): LKeyed<MessageMapState.Deleted>? {
         context.deleteMessageOnDevice(dto.localMsgId.toLong(), dto.isMms)
 
-        val mirroredDto = EventDto.DeleteSmsMirrored(state.globalMsgId, dto.metadata, dto.isMms)
-        context.mirrorEvent(mirroredDto)
+        if(context.mirrorConfig.isEnabled) {
+            val mirroredDto = EventDto.DeleteSmsMirrored(state.globalMsgId, dto.metadata, dto.isMms)
+            context.mirrorEvent(mirroredDto)
+        }
 
         return LKeyed(dto.localMsgId, MessageMapState.Deleted(state.rowId))
     }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsPartReceiveInUnknown.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsPartReceiveInUnknown.kt
@@ -2,6 +2,7 @@ package org.cpardi.messagemirror.stateMachines.handlers
 
 import android.content.Context
 import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.isEnabled
 import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.extensions.mirrorEvent
 import org.cpardi.messagemirror.extensions.serialise
@@ -10,7 +11,7 @@ import org.cpardi.messagemirror.models.Keyed
 
 class OnSmsPartReceiveInUnknown(val context: Context) {
     fun handle(dto: EventDto.SmsPartReceive): Keyed<MessageMapState> {
-        if (context.mirrorConfig.deviceID == dto.metadata.senderID) {
+        if (context.mirrorConfig.isEnabled && context.mirrorConfig.deviceID == dto.metadata.senderID) {
             context.mirrorEvent(EventDto.SmsReceiveMirrored(dto.metadata, dto.globalMsgId, dto.intent.serialise()))
         }
 

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendInMultipleStates.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendInMultipleStates.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.util.Log
 import org.cpardi.messagemirror.models.Keyed
 import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.isEnabled
 import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.extensions.mirrorEvent
 import org.cpardi.messagemirror.extensions.toGlobalMsgId
@@ -37,7 +38,10 @@ class OnSmsSendInMultipleStates(val context: Context) {
 
         Log.d(TAG, "Finish processing SMS send as requested by device ${send.metadata.senderID}")
 
-        context.mirrorEvent(EventDto.SmsSendMirrored(states.map { it.globalMsgId }, send))
+        if(context.mirrorConfig.isEnabled) {
+            context.mirrorEvent(EventDto.SmsSendMirrored(states.map { it.globalMsgId }, send))
+        }
+
         return states.toList()
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendStatusInAvailable.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/stateMachines/handlers/OnSmsSendStatusInAvailable.kt
@@ -2,13 +2,18 @@ package org.cpardi.messagemirror.stateMachines.handlers
 
 import android.content.Context
 import org.cpardi.messagemirror.databases.MessageMapState
+import org.cpardi.messagemirror.extensions.isEnabled
+import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.extensions.mirrorEvent
 import org.cpardi.messagemirror.models.EventDto
 import org.cpardi.messagemirror.models.Keyed
 
 class OnSmsSendStatusInAvailable(val context: Context) {
     fun handle(state: Keyed<MessageMapState.Available>, dto: EventDto.SmsSendStatus): Keyed<MessageMapState>? {
-        context.mirrorEvent(EventDto.SmsSendStatusMirrored(state.globalMsgId, dto))
+        if(context.mirrorConfig.isEnabled) {
+            context.mirrorEvent(EventDto.SmsSendStatusMirrored(state.globalMsgId, dto))
+        }
+
         return null
     }
 }

--- a/app/src/main/kotlin/org/cpardi/messagemirror/views/MirrorSettingsView.kt
+++ b/app/src/main/kotlin/org/cpardi/messagemirror/views/MirrorSettingsView.kt
@@ -17,10 +17,10 @@ import androidx.lifecycle.LifecycleOwner
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanIntentResult
 import com.journeyapps.barcodescanner.ScanOptions
-import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.dialogs.ShareMirrorSettingsDialog
 import org.cpardi.messagemirror.extensions.mirrorConfig
 import org.cpardi.messagemirror.helpers.Constants
+import org.cpardi.messagemirror.helpers.CryptoHelper
 import org.cpardi.messagemirror.helpers.MirrorConfig
 import org.cpardi.messagemirror.models.DeviceMode
 import org.fossify.commons.compose.extensions.getActivity
@@ -56,11 +56,13 @@ class MirrorSettingsView @JvmOverloads constructor(
     }
 
     private fun onHostResume() {
-        setupEnableMirrorSwitch()
         setupDeviceMode()
         setupTopic()
         setupGenerateTopic()
         setupCopyTopic()
+        setupCustomServerToggle()
+        setupCopyCustomServer()
+        setupCustomServer()
         setupEncryptionKey()
         setupGenerateKey()
         setupCopyKey()
@@ -73,6 +75,7 @@ class MirrorSettingsView @JvmOverloads constructor(
         arrayOf(
             binding.mirrorSettingsGenerateTopicButton,
             binding.mirrorSettingsCopyTopicButton,
+            binding.mirrorSettingsCopyCustomServerButton,
             binding.mirrorSettingsGenerateKeyButton,
             binding.mirrorSettingsCopyKeyButton,
         ).forEach {
@@ -84,43 +87,41 @@ class MirrorSettingsView @JvmOverloads constructor(
         }
     }
 
-    private fun setupEnableMirrorSwitch() = binding.apply {
-        val enabled = config.enabled
-        mirrorSettingsEnable.isChecked = enabled
-        setSettingsEnabled(enabled)
-
-        mirrorSettingsEnableHolder.setOnClickListener {
-            mirrorSettingsEnable.toggle()
-            val isChecked = mirrorSettingsEnable.isChecked
-            setSettingsEnabled(isChecked)
-            config.enabled = isChecked
-        }
-    }
-
     private fun setupDeviceMode() = binding.apply {
         val currentMode = config.mode
-        mirrorSettingsMode.text = currentMode.description()
+        mirrorSettingsMode.text = currentMode.description(context)
+        setSettingsEnabled(currentMode)
 
         mirrorSettingsModeHolder.setOnClickListener {
-            val items = DeviceMode.entries.map { id -> RadioItem(id.value, id.description()) }.toArrayList()
+            val items = DeviceMode.entries.map { id -> RadioItem(id.value, id.description(context)) }.toArrayList()
             val currentMode = config.mode
             RadioGroupDialog(context.getActivity(), items, currentMode.value) { selected ->
                 val mode = DeviceMode.fromInt(selected as Int)
-                mirrorSettingsMode.text = mode.description()
+                mirrorSettingsMode.text = mode.description(context)
+                setSettingsEnabled(mode)
                 config.mode = mode
             }
         }
     }
 
     private fun setupTopic() = binding.apply {
-        mirrorSettingsTopicEdittext.setText(config.topicUrl.toString())
+        mirrorSettingsTopicEdittext.setText(config.topic)
 
         mirrorSettingsTopicEdittext.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { // This is intentionally empty
             }
+
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                config.topicUrl = URI(s?.toString() ?: "")
+                val topic = s?.toString() ?: ""
+                if (!("\\w+".toRegex().matches(topic))) {
+                    mirrorSettingsTopicEdittext.error = "Please specify a valid topic name."
+                    return
+                }
+
+                mirrorSettingsTopicEdittext.error = null
+                config.topic = topic
             }
+
             override fun afterTextChanged(s: Editable?) { // This is intentionally empty
             }
         })
@@ -143,15 +144,71 @@ class MirrorSettingsView @JvmOverloads constructor(
         }
     }
 
+    private fun setupCustomServerToggle() = binding.apply {
+        val useCustomServer = context.mirrorConfig.baseUrl != URI(Constants.URL_NTFY_DEFAULT)
+        mirrorSettingsUseCustomServerCheckbox.isChecked = useCustomServer
+        mirrorSettingsCustomServerHolder.isVisible = useCustomServer
+        if (!useCustomServer)
+            mirrorSettingsCustomServerEdittext.setText(null)
+
+        mirrorSettingsUseCustomServerCheckbox.setOnCheckedChangeListener { _, isChecked ->
+            mirrorSettingsCustomServerHolder.isVisible = isChecked
+            if (!isChecked)
+                mirrorSettingsCustomServerEdittext.setText(null)
+        }
+    }
+
+    private fun setupCopyCustomServer() = binding.apply {
+        mirrorSettingsCopyCustomServerButton.setOnClickListener {
+            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val textToCopy = mirrorSettingsCustomServerEdittext.text.toString()
+            val clip = ClipData.newPlainText("Custom Server", textToCopy)
+            clipboard.setPrimaryClip(clip)
+            Toast.makeText(context, "Custom server copied to clipboard", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun setupCustomServer() = binding.apply {
+        mirrorSettingsCustomServerEdittext.setText(config.baseUrl.toString())
+
+        mirrorSettingsCustomServerEdittext.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { // This is intentionally empty
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                try {
+                    val baseUrlString = s?.toString()
+                    if (baseUrlString.isNullOrEmpty()) error("URL is empty")
+                    config.baseUrl = URI(baseUrlString)
+                    mirrorSettingsCustomServerEdittext.error = null
+                } catch (_: Exception) {
+                    mirrorSettingsCustomServerEdittext.error = "Please specify a valid http(s) URL."
+                }
+            }
+
+            override fun afterTextChanged(s: Editable?) { // This is intentionally empty
+            }
+        })
+    }
+
     private fun setupEncryptionKey() = binding.apply {
         mirrorSettingsKeyEdittext.setText(config.encryptionKey)
 
         mirrorSettingsKeyEdittext.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { // This is intentionally empty
             }
+
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                config.encryptionKey = s?.toString() ?: ""
+                val keyString = s?.toString()
+                if (!CryptoHelper.isValidEncryptionKey(keyString)) {
+                    mirrorSettingsKeyEdittext.error = "Please specify a valid encryption key."
+                    return
+                }
+
+                mirrorSettingsKeyEdittext.error = null
+                config.encryptionKey = keyString!!
             }
+
             override fun afterTextChanged(s: Editable?) { // This is intentionally empty
             }
         })
@@ -177,7 +234,7 @@ class MirrorSettingsView @JvmOverloads constructor(
 
     private fun setupShare() = binding.apply {
         mirrorSettingsShareHolder.setOnClickListener {
-            ShareMirrorSettingsDialog(context, "${config.topicUrl};${config.encryptionKey}")
+            ShareMirrorSettingsDialog(context, "${config.topic};${config.encryptionKey};${config.baseUrl}")
         }
     }
 
@@ -202,7 +259,7 @@ class MirrorSettingsView @JvmOverloads constructor(
             return
 
         val topicAndKey = contents.split(';')
-        if (topicAndKey.size != 2) {
+        if (topicAndKey.size != NUM_QRCODE_FIELDS) {
             Toast.makeText(
                 context,
                 "Invalid QR code format. Please scan a valid mirror settings QR code.",
@@ -213,10 +270,12 @@ class MirrorSettingsView @JvmOverloads constructor(
 
         binding.mirrorSettingsTopicEdittext.setText(topicAndKey[0])
         binding.mirrorSettingsKeyEdittext.setText(topicAndKey[1])
+        binding.mirrorSettingsUseCustomServerCheckbox.isChecked = topicAndKey[2] != Constants.URL_NTFY_DEFAULT
+        binding.mirrorSettingsCustomServerEdittext.setText(topicAndKey[2])
     }
 
-    private fun setSettingsEnabled(isEnabled: Boolean) = binding.apply {
-        mirrorSettingsEnable.isChecked = isEnabled
+    private fun setSettingsEnabled(deviceMode: DeviceMode) = binding.apply {
+        val isEnabled = deviceMode != DeviceMode.None
         mirrorSettingsControlsHolder.isEnabled = isEnabled
         mirrorSettingsControlsHolder.isVisible = isEnabled
         mirrorSettingsNtfyWarning.isVisible = !context.isPackageInstalled(Constants.PACKAGE_NTFY)
@@ -228,5 +287,9 @@ class MirrorSettingsView @JvmOverloads constructor(
         return (1..length)
             .map { charset[secureRandom.nextInt(charset.size)] }
             .joinToString("")
+    }
+
+    companion object {
+        const val  NUM_QRCODE_FIELDS: Int = 3
     }
 }

--- a/app/src/main/kotlin/org/fossify/messages/messaging/SmsSender.kt
+++ b/app/src/main/kotlin/org/fossify/messages/messaging/SmsSender.kt
@@ -134,9 +134,9 @@ class SmsSender(val app: Application): ISmsSender {
 
             if (mode != instance?.forMode) {
                 instance = when(mode) {
+                    DeviceMode.None -> SmsSender(app)
                     DeviceMode.SmsHost -> LoggingSmsSender(SmsSender(app))
                     DeviceMode.Mirror -> NullSmsSender()
-                    else -> throw NoWhenBranchMatchedException("Device mode case isn't implemented")
                 }
             }
             return instance!!

--- a/app/src/main/res/drawable/baseline_autorenew_24.xml
+++ b/app/src/main/res/drawable/baseline_autorenew_24.xml
@@ -1,5 +1,5 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="40dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="40dp">
-      
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
     <path android:fillColor="@android:color/white" android:pathData="M12,6v3l4,-4 -4,-4v3c-4.42,0 -8,3.58 -8,8 0,1.57 0.46,3.03 1.24,4.26L6.7,14.8c-0.45,-0.83 -0.7,-1.79 -0.7,-2.8 0,-3.31 2.69,-6 6,-6zM18.76,7.74L17.3,9.2c0.44,0.84 0.7,1.79 0.7,2.8 0,3.31 -2.69,6 -6,6v-3l-4,4 4,4v-3c4.42,0 8,-3.58 8,-8 0,-1.57 -0.46,-3.03 -1.24,-4.26z"/>
-    
+
 </vector>

--- a/app/src/main/res/drawable/baseline_content_copy_24.xml
+++ b/app/src/main/res/drawable/baseline_content_copy_24.xml
@@ -1,5 +1,5 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
-      
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="22dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="22dp">
+
     <path android:fillColor="@android:color/white" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
-    
+
 </vector>

--- a/app/src/main/res/layout/dialog_share_mirror_settings.xml
+++ b/app/src/main/res/layout/dialog_share_mirror_settings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/share_mirror_settings_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/share_mirror_settings_title"
+        style="@style/SettingsSectionLabelStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/share_mirror_settings" />
+
+    <RelativeLayout
+        android:id="@+id/share_mirror_settings_holder"
+        style="@style/SettingsHolderTextViewStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/share_mirror_settings_message"
+            style="@style/SettingsTextLabelStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/share_mirror_settings_description" />
+    </RelativeLayout>
+
+    <ImageView
+        android:id="@+id/share_mirror_settings_qr_code"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="0dp"
+        android:contentDescription="@string/qr_code"
+        android:background="@android:color/white"
+        android:scaleType="fitCenter" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/view_mirror_settings.xml
+++ b/app/src/main/res/layout/view_mirror_settings.xml
@@ -15,19 +15,26 @@
             android:layout_height="wrap_content"
             android:text="@string/mirror" />
 
+        <!-- Mode setting -->
         <RelativeLayout
-            android:id="@+id/mirror_settings_enable_holder"
-            style="@style/SettingsHolderSwitchStyle"
+            android:id="@+id/mirror_settings_mode_holder"
+            style="@style/SettingsHolderTextViewStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <org.fossify.commons.views.MyMaterialSwitch
-                android:id="@+id/mirror_settings_enable"
-                style="@style/SettingsSwitchStyle"
-                android:layout_width="match_parent"
+            <org.fossify.commons.views.MyTextView
+                android:id="@+id/mirror_settings_mode_label"
+                style="@style/SettingsTextLabelStyle"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/enable_mirror" />
+                android:text="@string/device_mode" />
 
+            <org.fossify.commons.views.MyTextView
+                android:id="@+id/mirror_settings_mode"
+                style="@style/SettingsTextValueStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/mirror_settings_mode_label" />
         </RelativeLayout>
 
         <LinearLayout
@@ -49,138 +56,171 @@
                 android:visibility="gone"
                 android:textAppearance="?attr/textAppearanceBody2" />
 
-            <!-- Mode setting -->
-            <RelativeLayout
-                android:id="@+id/mirror_settings_mode_holder"
-                style="@style/SettingsHolderTextViewStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <org.fossify.commons.views.MyTextView
-                    android:id="@+id/mirror_settings_mode_label"
-                    style="@style/SettingsTextLabelStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/device_mode" />
-
-                <org.fossify.commons.views.MyTextView
-                    android:id="@+id/mirror_settings_mode"
-                    style="@style/SettingsTextValueStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@+id/mirror_settings_mode_label" />
-            </RelativeLayout>
-
-            <!-- Topic setting with Generate and Copy buttons -->
-            <RelativeLayout
+            <!-- Topic setting with title and smaller buttons horizontally, EditText below -->
+            <LinearLayout
                 android:id="@+id/mirror_settings_topic_holder"
                 style="@style/SettingsHolderTextViewOneLinerStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
                 android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:gravity="center_vertical">
+                android:paddingEnd="16dp">
 
-                <org.fossify.commons.views.MyTextView
-                    android:id="@+id/mirror_settings_topic_label"
-                    style="@style/SettingsTextLabelStyle"
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <org.fossify.commons.views.MyTextView
+                        android:id="@+id/mirror_settings_topic_label"
+                        style="@style/SettingsTextLabelStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/topic_url" />
+
+                    <org.fossify.commons.views.MyButton
+                        android:id="@+id/mirror_settings_generate_topic_button"
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:background="?selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/generate_random_topic"
+                        android:drawableTop="@drawable/baseline_autorenew_24"
+                        android:padding="4dp"
+                        android:layout_marginEnd="4dp" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingTop="4dp">
+
+                    <org.fossify.commons.views.MyEditText
+                        android:id="@+id/mirror_settings_topic_edittext"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:inputType="textUri"
+                        android:singleLine="true"
+                        android:imeOptions="actionDone"
+                        android:hint="@string/example_topic" />
+
+                    <org.fossify.commons.views.MyButton
+                        android:id="@+id/mirror_settings_copy_topic_button"
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:background="?selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/copy_to_clipboard"
+                        android:drawableTop="@drawable/baseline_content_copy_24"
+                        android:padding="4dp"
+                        android:layout_marginStart="8dp" />
+                </LinearLayout>
+
+                <org.fossify.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/mirror_settings_use_custom_server_checkbox"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/topic_url" />
+                    android:text="@string/use_custom_server" />
 
-                <org.fossify.commons.views.MyEditText
-                    android:id="@+id/mirror_settings_topic_edittext"
-                    android:layout_width="0dp"
+                <LinearLayout
+                    android:id="@+id/mirror_settings_custom_server_holder"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_toEndOf="@id/mirror_settings_topic_label"
-                    android:layout_toStartOf="@id/mirror_settings_generate_topic_button"
-                    android:layout_marginStart="26dp"
-                    android:layout_marginEnd="8dp"
-                    android:inputType="textUri"
-                    android:singleLine="true"
-                    android:imeOptions="actionDone"
-                    android:gravity="end|center_vertical"
-                    android:hint="@string/example_topic" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
 
-                <org.fossify.commons.views.MyButton
-                    android:id="@+id/mirror_settings_generate_topic_button"
-                    android:layout_width="@dimen/normal_icon_size"
-                    android:layout_height="@dimen/normal_icon_size"
-                    android:layout_alignParentEnd="true"
-                    android:layout_centerVertical="true"
-                    android:layout_marginEnd="48dp"
-                    android:background="?selectableItemBackgroundBorderless"
-                    android:clickable="false"
-                    android:contentDescription="@string/generate_random_topic"
-                    android:drawableTop="@drawable/baseline_autorenew_24"
-                    android:paddingVertical="@dimen/small_margin" />
+                    <org.fossify.commons.views.MyEditText
+                        android:id="@+id/mirror_settings_custom_server_edittext"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:inputType="textUri"
+                        android:singleLine="true"
+                        android:imeOptions="actionDone"
+                        android:hint="@string/example_custom_server" />
 
-                <org.fossify.commons.views.MyButton
-                    android:id="@+id/mirror_settings_copy_topic_button"
-                    android:layout_width="@dimen/normal_icon_size"
-                    android:layout_height="@dimen/normal_icon_size"
-                    android:layout_alignParentEnd="true"
-                    android:layout_centerVertical="true"
-                    android:background="?selectableItemBackgroundBorderless"
-                    android:contentDescription="@string/copy_topic_to_clipboard"
-                    android:drawableTop="@drawable/baseline_content_copy_24"
-                    android:paddingVertical="@dimen/medium_margin" />
+                    <org.fossify.commons.views.MyButton
+                        android:id="@+id/mirror_settings_copy_custom_server_button"
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:background="?selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/copy_to_clipboard"
+                        android:drawableTop="@drawable/baseline_content_copy_24"
+                        android:padding="4dp"
+                        android:layout_marginStart="8dp" />
+                </LinearLayout>
 
-            </RelativeLayout>
+                <TextView
+                    android:id="@+id/mirror_settings_topic_reminder"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/topic_reminder"
+                    android:textColor="@color/design_default_color_primary"
+                    android:textAppearance="?attr/textAppearanceBody2" />
+            </LinearLayout>
 
-            <RelativeLayout
+            <!-- Key setting with title and smaller buttons horizontally, EditText below -->
+            <LinearLayout
                 android:id="@+id/mirror_settings_key_holder"
-                style="@style/SettingsHolderTextViewOneLinerStyle"
+                style="@style/SettingsHolderTextViewStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
                 android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:gravity="center_vertical">
+                android:paddingEnd="16dp">
 
-                <org.fossify.commons.views.MyTextView
-                    android:id="@+id/mirror_settings_key_label"
-                    style="@style/SettingsTextLabelStyle"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/encryption_key" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
 
-                <org.fossify.commons.views.MyEditText
-                    android:id="@+id/mirror_settings_key_edittext"
-                    android:layout_width="0dp"
+                    <org.fossify.commons.views.MyTextView
+                        android:id="@+id/mirror_settings_key_label"
+                        style="@style/SettingsTextLabelStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/encryption_key" />
+
+                    <org.fossify.commons.views.MyButton
+                        android:id="@+id/mirror_settings_generate_key_button"
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:background="?selectableItemBackgroundBorderless"
+                        android:drawableTop="@drawable/baseline_autorenew_24"
+                        android:padding="4dp"
+                        android:layout_marginEnd="4dp" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_toEndOf="@id/mirror_settings_key_label"
-                    android:layout_toStartOf="@id/mirror_settings_generate_key_button"
-                    android:layout_marginStart="26dp"
-                    android:layout_marginEnd="8dp"
-                    android:inputType="textUri"
-                    android:singleLine="true"
-                    android:imeOptions="actionDone"
-                    android:gravity="end|center_vertical" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
 
-                <org.fossify.commons.views.MyButton
-                    android:id="@+id/mirror_settings_generate_key_button"
-                    android:layout_width="@dimen/normal_icon_size"
-                    android:layout_height="@dimen/normal_icon_size"
-                    android:layout_alignParentEnd="true"
-                    android:layout_centerVertical="true"
-                    android:layout_marginEnd="48dp"
-                    android:background="?selectableItemBackgroundBorderless"
-                    android:contentDescription="@string/generate_random_key"
-                    android:drawableTop="@drawable/baseline_autorenew_24"
-                    android:paddingVertical="@dimen/small_margin" />
+                    <org.fossify.commons.views.MyEditText
+                        android:id="@+id/mirror_settings_key_edittext"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:inputType="textUri"
+                        android:singleLine="true"
+                        android:imeOptions="actionDone"
+                        android:hint="@string/example_key" />
 
-                <org.fossify.commons.views.MyButton
-                    android:id="@+id/mirror_settings_copy_key_button"
-                    android:layout_width="@dimen/normal_icon_size"
-                    android:layout_height="@dimen/normal_icon_size"
-                    android:layout_alignParentEnd="true"
-                    android:layout_centerVertical="true"
-                    android:background="?selectableItemBackgroundBorderless"
-                    android:contentDescription="@string/copy_key_to_clipboard"
-                    android:drawableTop="@drawable/baseline_content_copy_24"
-                    android:paddingVertical="@dimen/medium_margin" />
-
-            </RelativeLayout>
+                    <org.fossify.commons.views.MyButton
+                        android:id="@+id/mirror_settings_copy_key_button"
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:background="?selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/copy_to_clipboard"
+                        android:drawableTop="@drawable/baseline_content_copy_24"
+                        android:padding="4dp"
+                        android:layout_marginEnd="0dp" />
+                </LinearLayout>
+            </LinearLayout>
 
             <RelativeLayout
                 android:id="@+id/mirror_settings_share_holder"
@@ -197,20 +237,20 @@
 
             </RelativeLayout>
 
-        </LinearLayout>
-
-        <RelativeLayout
-            android:id="@+id/mirror_settings_scan_holder"
-            style="@style/SettingsHolderTextViewOneLinerStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <org.fossify.commons.views.MyTextView
-                android:id="@+id/mirror_settings_scan_button"
-                style="@style/SettingsTextLabelStyle"
+            <RelativeLayout
+                android:id="@+id/mirror_settings_scan_holder"
+                style="@style/SettingsHolderTextViewOneLinerStyle"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/scan_settings" />
-        </RelativeLayout>
+                android:layout_height="wrap_content">
+
+                <org.fossify.commons.views.MyTextView
+                    android:id="@+id/mirror_settings_scan_button"
+                    style="@style/SettingsTextLabelStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/scan_settings" />
+            </RelativeLayout>
+
+        </LinearLayout>
     </LinearLayout>
 </merge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,17 +142,27 @@
     <!-- Messages Mirror -->
     <string name="mirror">Mirror</string>
     <string name="enable_mirror">Enable Mirror</string>
-    <string name="ntfy_warning">Warning: ntfy.sh app is not installed. Please install it from the Play Store.</string>
+    <string name="ntfy_warning">Warning: ntfy.sh app is not installed. Please install it use the mirror.</string>
+    <string name="topic_reminder">Remember to subscribe to this topic in ntfy.sh.</string>
     <string name="device_mode">Device Mode</string>
+    <string name="device_mode_none">None</string>
+    <string name="device_mode_sms_host">SMS Host</string>
+    <string name="device_mode_mirror">Mirror</string>
     <string name="topic_url">Topic URL</string>
-    <string name="example_topic">JCCtIRlCnhkr3Tky</string>
+    <string name="example_topic">Generate or specify topic name</string>
     <string name="generate_random_topic">Generate random topic</string>
-    <string name="copy_topic_to_clipboard">Copy topic to clipboard</string>
+    <string name="copy_to_clipboard">Copy to clipboard</string>
+    <string name="example_custom_server">Specify server base URL</string>
     <string name="encryption_key">Encryption Key</string>
-    <string name="generate_random_key">Generate random key</string>
-    <string name="copy_key_to_clipboard">Copy key to clipboard</string>
+    <string name="example_key">Generate or specify key</string>
     <string name="share_settings">Share Settings</string>
     <string name="scan_settings">Scan Settings</string>
+    <string name="add_topic_to_ntfy">ADD TOPIC TO NTFY...</string>
+    <string name="use_custom_server">Use another server</string>
+    <string name="custom_server_address">https://ntfy.sh</string>
+    <string name="share_mirror_settings">Share Mirror Settings</string>
+    <string name="share_mirror_settings_description">To sync settings, choose \'Scan Settings\' on your other device and scan this QR code.</string>
+    <string name="qr_code">QR code</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/res


### PR DESCRIPTION
- Add DeviceMode.None and update MirrorConfig to use mode instead of enabled flag
- Add UI elements for custom server toggle, input, and copy button
    - Update QR code sharing and scanning to include custom server URL
- Add validation for topic, server toggle and encryption key inputs
- Refactor ShareMirrorSettingsDialog to respect color scheme with title and message
- Adjust vector drawable sizes for icons

Also:

- Update EventConsumerService and state machine handlers to respect device mode and enabled state as exceptions were being thrown when Mirror was not enabled.